### PR TITLE
Refactor query number

### DIFF
--- a/docs/source/dev_documentation/changelog.md
+++ b/docs/source/dev_documentation/changelog.md
@@ -15,7 +15,7 @@
 - 🚨 BREAKING CHANGE 🚨 `checks` attribute has been given for all `TransactionStep`, sometimes replacing `check_success`
 - 🚨 BREAKING CHANGE 🚨 `.` and `[]` are used instead of `%` to specify a `Scenario` value key
 - Upgrade MultiversX python libraries
-
+- `int` is preferred over `number` for query return type
 
 ### Fixed
 

--- a/docs/source/examples/python_steps.md
+++ b/docs/source/examples/python_steps.md
@@ -158,7 +158,7 @@ def fetch_pool_data(contract: str) -> Tuple[int, str, str]:
     quote_token_query.execute()
     
     # extract the results (we expect to have exactly one result per query)
-    pool_price = parse_query_result(price_query.results[0], "number")
+    pool_price = parse_query_result(price_query.results[0], "int")
     base_token = parse_query_result(base_token_query.results[0], "str")
     quote_token = parse_query_result(quote_token_query.results[0], "str")
     return pool_price, base_token, quote_token

--- a/docs/source/getting_started/enhanced_first_scene.md
+++ b/docs/source/getting_started/enhanced_first_scene.md
@@ -93,7 +93,7 @@ Such `Step` would look like this:
     endpoint: getPingAmount
     expected_results:
       - save_key: PingAmount
-        result_type: number
+        result_type: int
 ```
 
 This tells `MxOps` to save (in the current `Scenario`) the value from the query result and to attach it to the contract "egld-ping-pong" under the key name "PingAmount".
@@ -157,7 +157,7 @@ steps:
     endpoint: getPingAmount
     expected_results:
       - save_key: PingAmount
-        result_type: number
+        result_type: int
 
   - type: ContractCall
     sender: owner

--- a/docs/source/getting_started/presentation.md
+++ b/docs/source/getting_started/presentation.md
@@ -84,7 +84,7 @@ Here is the above `Scene`, but this time with the MxOps syntax:
           - "[owner]"
       expected_results:
         - save_key: ownerStakedAmount
-          result_type: number
+          result_type: int
 
     - type: ContractCall
       sender: owner

--- a/docs/source/user_documentation/steps.md
+++ b/docs/source/user_documentation/steps.md
@@ -146,7 +146,7 @@ expected_results: # list of results excpected from the query output
 print_results: false # if the query results should be printed in the console
 ```
 
-Currently allowed values for `result_type`: [`number`, `str`]
+Currently allowed values for `result_type`: [`int`, `str`]
 
 (loop_step_target)=
 
@@ -389,7 +389,7 @@ steps:
       - $LOOP_VAR # nonce
     expected_results:
       - save_key: TokenIdentifier4Amount
-        result_type: number
+        result_type: int
 
   - type: ContractCall
     sender: alice

--- a/mxops/execution/steps.py
+++ b/mxops/execution/steps.py
@@ -392,10 +392,10 @@ class ContractQueryStep(Step):
             as_bytes = base64.b64decode(data)
             as_hex = as_bytes.hex()
             try:
-                as_number = int(str(int(as_hex or "0", 16)))
+                as_int = int(str(int(as_hex or "0", 16)))
             except (ValueError, TypeError):
-                as_number = None
-            result = QueryResult(data, as_hex, as_number)
+                as_int = None
+            result = QueryResult(data, as_hex, as_int)
             return result
         except Exception as err:
             raise errors.ParsingError(data, "QueryResult") from err

--- a/mxops/execution/utils.py
+++ b/mxops/execution/utils.py
@@ -289,7 +289,7 @@ def parse_query_result(result: QueryResult, expected_return: str) -> Any:
     :return: parsed result of the query
     :rtype: Any
     """
-    if expected_return == "number":
+    if expected_return in ("number", "int"):
         return result.number
     if expected_return == "str":
         return bytes.fromhex(result.hex).decode()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mxops"
-version = "2.0.0-dev3"
+version = "2.0.0-dev4"
 authors = [
   {name="Etienne Wallet"},
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.0-dev3
+current_version = 2.0.0-dev4
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<release>\w+)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}{build}

--- a/tutorials/enhanced_first_scene/mxops_scenes/ping_pong.yaml
+++ b/tutorials/enhanced_first_scene/mxops_scenes/ping_pong.yaml
@@ -12,7 +12,7 @@ steps:
     endpoint: getPingAmount
     expected_results:
       - save_key: PingAmount
-        result_type: number
+        result_type: int
 
   - type: ContractCall
     sender: owner


### PR DESCRIPTION
Changed:
- `int` is now preferred over `number` when specifying query return type for save