### PR TITLE
Breaking/versioned scenario data

### DIFF
--- a/docs/source/dev_documentation/changelog.md
+++ b/docs/source/dev_documentation/changelog.md
@@ -28,6 +28,7 @@
 - 🚨 BREAKING CHANGE 🚨 account's addresses can no longer be accessed with "[<account_id>]"
 - `Scenes` have now default values for allowed scenarios and allowed networks
 - 🚨 BREAKING CHANGE 🚨 removed analyze feature from MxOps
+- 🚨 BREAKING CHANGE 🚨 rework the data save structure and introduce versioned data structure
 
 ## 2.2.0 - 2024-04-16
 

--- a/mxops/__main__.py
+++ b/mxops/__main__.py
@@ -12,6 +12,7 @@ from importlib_resources import files
 
 from mxops.config import cli as config_cli
 from mxops.data import cli as data_cli
+from mxops.data.migrations.run import check_migrate_data
 from mxops.execution import cli as execution_cli
 
 
@@ -43,6 +44,7 @@ def main():
     intendend functions.
     """
     args = parse_args()
+    check_migrate_data()
 
     print(
         "MxOps  Copyright (C) 2023  Catenscia",

--- a/mxops/data/cli.py
+++ b/mxops/data/cli.py
@@ -59,7 +59,7 @@ def add_subparser(subparsers_action: _SubParsersAction):
         "--network",
         help="Name of the network to use",
         type=parse_network_enum,
-        required=True,
+        default="chain-simulator",
     )
 
     get_parser.add_argument(

--- a/mxops/data/migrations/__init__.py
+++ b/mxops/data/migrations/__init__.py
@@ -1,0 +1,8 @@
+"""
+author: Etienne Wallet
+
+This sub-package contains the functions to migrate the mxops data from
+one version to another. This sub-package should be completely independant
+of the mxops package, to the exception of the sub-package path_version,
+the config and the network enums
+"""

--- a/mxops/data/migrations/run.py
+++ b/mxops/data/migrations/run.py
@@ -1,0 +1,92 @@
+"""
+author: Etienne Wallet
+
+This module host functions to coordinate and run the migrations
+"""
+
+import importlib
+import pkgutil
+
+from mxops.data import path_versions
+from mxops.data.path_versions.msc import version_name_to_version_path_name
+from mxops.utils.logger import get_logger
+
+
+LOGGER = get_logger("migration")
+
+
+def get_all_versions() -> list[str]:
+    """
+    Return all the existing data version, sorted from old to new
+
+    :return: sorted versions
+    :rtype: list[str]
+    """
+    versions = []
+    for _, module_name, is_pkg in pkgutil.iter_modules(path_versions.__path__):
+        if is_pkg:
+            continue
+        if not module_name.startswith("v"):
+            continue
+        module = importlib.import_module(f"mxops.data.path_versions.{module_name}")
+        try:
+            versions.append(module.VERSION)
+        except AttributeError:
+            pass
+    versions.sort(key=lambda x: tuple(x.split(".")))
+    return versions
+
+
+def get_current_local_data_version(versions: list[str]) -> str | None:
+    """
+    Determine which version is the one currently saved
+    Return None if no version is matched
+
+    :param versions: all available versions
+    :type versions: list[str]
+    :return: version
+    :rtype: str | None
+    """
+    for version in versions:
+        module_name = version_name_to_version_path_name(version)
+        module = importlib.import_module(f"mxops.data.path_versions.{module_name}")
+        if module.is_current_saved_version():
+            return version
+    return None
+
+
+def check_migrate_data():
+    """
+    Check the current data version and run the migration if needed
+    """
+    versions = get_all_versions()
+    LOGGER.debug(f"Versions found: {versions}")
+    current_saved_version = get_current_local_data_version(versions)
+    if current_saved_version is None:
+        LOGGER.debug("No data version match")
+        return
+    if current_saved_version == versions[-1]:
+        LOGGER.debug("Current data version is the latest")
+        return
+    LOGGER.info("Current data version is not up to date. Migrating existing data")
+    i = versions.index(current_saved_version)
+    n_versions = len(versions)
+    while i + 1 < n_versions:
+        source_version = versions[i]
+        dest_version = versions[i + 1]
+        LOGGER.info(f"Migrating saved data from {source_version} to {dest_version}")
+        module_name = (
+            f"{version_name_to_version_path_name(source_version)}__to__"
+            f"{version_name_to_version_path_name(dest_version)}"
+        )
+        LOGGER.debug(f"Migration module: {module_name}")
+        module = importlib.import_module(f"mxops.data.migrations.{module_name}")
+        module.migrate()
+        LOGGER.info("Migration completed")
+        i += 1
+    last_version_module_name = version_name_to_version_path_name(versions[-1])
+    last_version_module = importlib.import_module(
+        f"mxops.data.path_versions.{last_version_module_name}"
+    )
+    last_version_module.register_as_current()
+    LOGGER.info("All migrations completed")

--- a/mxops/data/migrations/v0_1_0__to__v1_0_0.py
+++ b/mxops/data/migrations/v0_1_0__to__v1_0_0.py
@@ -1,0 +1,236 @@
+"""
+author: Etienne Wallet
+
+This modules contains the functions to migration mxops data from v0.1.0 to v1.0.0
+"""
+
+from copy import deepcopy
+import json
+
+from mxops.config.config import Config
+from mxops.data.path_versions import v0_1_0, v1_0_0
+from mxops.enums import NetworkEnum
+
+
+def recursive_attribute_drop(data: dict, attribute_name: str) -> dict:
+    """
+    Recusrively remove the provided attribute of a dictionnary
+    if the value is a list of null length
+
+    :param data: dict to inspect
+    :type data: dict
+    :param attribute_name: name of the attribute to inspect
+    :type attribute_name: str
+    :return: pruned dictionnary
+    :rtype: dict
+    """
+    if attribute_name in data and len(data[attribute_name]) == 0:
+        data.pop(attribute_name)
+    for key, value in data.items():
+        if isinstance(value, dict):
+            data[key] = recursive_attribute_drop(value, attribute_name)
+        if isinstance(value, list):
+            data[key] = [
+                recursive_attribute_drop(v, attribute_name)
+                if isinstance(v, dict)
+                else v
+                for v in value
+            ]
+    return data
+
+
+def reconstruct_endpoint_data(data: dict, is_constructor: bool = False) -> dict:
+    """
+    From the endpoint data of a serializer, reconstruct the data
+    for an abi file
+
+    :param data: endpoint to reconstruct
+    :type data: dict
+    :param is_constructor: if the endpoint is a constructor endpoint, defaults to False
+    :type is_constructor: bool, optional
+    :return: reconstructed endpoint
+    :rtype: dict
+    """
+    data = recursive_attribute_drop(data, "docs")
+    if is_constructor:
+        data.pop("mutability", "")
+        data.pop("name", "")
+    return data
+
+
+def reconstruct_struct_data(data: dict) -> dict:
+    """
+    From the struct data of a serializer, reconstruct the data for
+    an abi file
+
+    :param data: struct to reconstruct
+    :type data: dict
+    :return: reconstructed struct
+    :rtype: dict
+    """
+    data.pop("name", "")
+    data = recursive_attribute_drop(data, "docs")
+    data = recursive_attribute_drop(data, "fields")
+    data["type"] = "struct"
+    return data
+
+
+def reconstruct_enum_data(data: dict) -> dict:
+    """
+    From the enum data of a serializer, reconstruct the data for
+    an abi file
+
+    :param data: enum to reconstruct
+    :type data: dict
+    :return: reconstructed enum
+    :rtype: dict
+    """
+    data.pop("name", "")
+    data = recursive_attribute_drop(data, "docs")
+    data = recursive_attribute_drop(data, "fields")
+    data["type"] = "enum"
+    return data
+
+
+def reconstruct_abi_from_serializer_dict(
+    contract_id: str, serializer_data: dict
+) -> dict:
+    """
+    Reconstruct an partial abi file from the dictionary representation
+    of a AbiSerializer
+
+    :param contract_id: id of the contract that had the provided serializer
+    :type contract_id: str
+    :param serializer_data: AbiSerializer as a dict
+    :type serializer_data: dict
+    :return: partial abi file
+    :rtype: dict
+    """
+    data_copy = deepcopy(serializer_data)
+    endpoints: dict = data_copy.get("endpoints", {})
+    contract_abi = {
+        "name": contract_id,
+        "esdtAttributes": [],
+        "hasCallback": False,
+        "types": {},
+    }
+    contract_abi["constructor"] = reconstruct_endpoint_data(endpoints.pop("init"), True)
+
+    if "upgrade" in endpoints:
+        upgrade_endpoint = endpoints.pop("upgrade")
+    elif "upgradeConstructor" in endpoints:
+        upgrade_endpoint = endpoints.pop("upgradeConstructor")
+    contract_abi["upgradeConstructor"] = reconstruct_endpoint_data(
+        upgrade_endpoint, True
+    )
+
+    contract_abi["endpoints"] = [
+        reconstruct_endpoint_data(e) for e in endpoints.values()
+    ]
+
+    for struct in data_copy["structs"].values():
+        struct_name = struct["name"]
+        contract_abi["types"][struct_name] = reconstruct_struct_data(struct)
+
+    for enum in data_copy["enums"].values():
+        enum_name = enum["name"]
+        contract_abi["types"][enum_name] = reconstruct_enum_data(enum)
+    return contract_abi
+
+
+def convert_scenario(source_data: dict) -> tuple[dict, dict[str, dict]]:
+    """
+    Convert a scenario file from v0.1.0 to the elements needed for v.1.0.0
+
+    :param source_data: json file of a scenario under the v0.1.0
+    :type source_data: dict
+    :return: json file of the scenario under v1.0.0 and the reconstructed json abis
+    :rtype: tuple[dict, dict[str, dict]]
+    """
+    abis = {}
+    dest_data = deepcopy(source_data)
+    for contract_id, contract_data in dest_data["contracts_data"].items():
+        serializer_data = contract_data.pop("serializer", None)
+        if serializer_data is not None:
+            abis[contract_id] = reconstruct_abi_from_serializer_dict(
+                contract_id, serializer_data
+            )
+    return dest_data, abis
+
+
+def migrate_scenario(scenario_name: str, scenario_data: dict):
+    """
+    Convert the data of a scenario from version v0.1.0 to version
+    v1.0.0 and save the resulting data
+
+    :param scenario_name: name of the scenario to convert
+    :type scenario_name: str
+    :param scenario_data: data to convert
+    :type scenario_data: dict
+    """
+    converted_data, abis = convert_scenario(scenario_data)
+    data_file_path = v1_0_0.get_scenario_current_data_path(scenario_name)
+    data_file_path.parent.mkdir(parents=True, exist_ok=True)
+    data_file_path.write_text(json.dumps(converted_data, indent=4))
+
+    for contract_id, abi_data in abis.items():
+        abis_file_path = v1_0_0.get_contract_abi_file_path(scenario_name, contract_id)
+        abis_file_path.parent.mkdir(parents=True, exist_ok=True)
+        abis_file_path.write_text(json.dumps(abi_data, indent=4))
+
+
+def migrate_scenario_checkpoint(
+    scenario_name: str, checkpoint_name: str, scenario_data: dict
+):
+    """
+    Convert the data of a checkpoint of a scenario from version v0.1.0 to version
+    v1.0.0 and save the resulting data
+
+    :param scenario_name: name of the scenario to convert
+    :type scenario_name: str
+    :param checkpoint_name: name of the checkpoint of the scenario
+    :type checkpoint_name: str
+    :param scenario_data: data to convert
+    :type scenario_data: dict
+    """
+    converted_data, abis = convert_scenario(scenario_data)
+    data_file_path = v1_0_0.get_scenario_checkpoint_data_path(
+        scenario_name, checkpoint_name
+    )
+    data_file_path.parent.mkdir(parents=True, exist_ok=True)
+    data_file_path.write_text(json.dumps(converted_data, indent=4))
+
+    for contract_id, abi_data in abis.items():
+        abis_file_path = v1_0_0.get_checkpoint_contract_abi_file_path(
+            scenario_name, checkpoint_name, contract_id
+        )
+        abis_file_path.parent.mkdir(parents=True, exist_ok=True)
+        abis_file_path.write_text(json.dumps(abi_data, indent=4))
+
+
+def migrate():
+    """
+    Operate the migration of mxops data from v0.1.0 to v1.0.0
+    """
+    root_source_path = v0_1_0.get_data_path()
+    for network in NetworkEnum:
+        env_source_path = root_source_path / network.name
+        if not env_source_path.exists():
+            continue
+        Config.set_network(network)
+        scenarios_names = v0_1_0.get_all_scenarios_names()
+        for scenario_name in scenarios_names:
+            scenario_data = json.loads(
+                v0_1_0.get_scenario_file_path(scenario_name).read_text()
+            )
+            migrate_scenario(scenario_name, scenario_data)
+            checkpoints_names = v0_1_0.get_all_checkpoints_names(scenario_name)
+            for checkpoint_name in checkpoints_names:
+                scenario_data = json.loads(
+                    v0_1_0.get_scenario_file_path(
+                        scenario_name, checkpoint_name
+                    ).read_text()
+                )
+                migrate_scenario_checkpoint(
+                    scenario_name, checkpoint_name, scenario_data
+                )

--- a/mxops/data/path_versions/__init__.py
+++ b/mxops/data/path_versions/__init__.py
@@ -1,0 +1,8 @@
+"""
+author: Etienne Wallet
+
+This sub-package contains the classes and the functions used to manage
+the data for each version of the data model
+"""
+
+CURRENT_VERSION = "1.0.0"

--- a/mxops/data/path_versions/__init__.py
+++ b/mxops/data/path_versions/__init__.py
@@ -4,5 +4,3 @@ author: Etienne Wallet
 This sub-package contains the classes and the functions used to manage
 the data for each version of the data model
 """
-
-CURRENT_VERSION = "1.0.0"

--- a/mxops/data/path_versions/msc.py
+++ b/mxops/data/path_versions/msc.py
@@ -1,0 +1,19 @@
+"""
+author: Etienne Wallet
+
+This module contains miscellanious functions for the sub package
+
+"""
+
+
+def version_name_to_version_path_name(version: str) -> str:
+    """
+    Convert a version name (v1.0.0) to the equivalent as a path (v1_0_0).
+    It replaces the dots by underscores
+
+    :param version: version to convert
+    :type version: str
+    :return: converted version
+    :rtype: str
+    """
+    return version.replace(".", "_")

--- a/mxops/data/path_versions/v0_1_0.py
+++ b/mxops/data/path_versions/v0_1_0.py
@@ -47,6 +47,18 @@ def get_data_path() -> Path:
     return Path(app_dirs.user_data_dir)
 
 
+def is_current_saved_version() -> bool:
+    """
+    Check if the current data version saved is the v0.1.0
+    This is the only version without a version file
+
+    :return: version number
+    :rtype: str
+    """
+    file_path = get_data_path() / "VERSION"
+    return file_path.parent.exists() and not file_path.exists()
+
+
 def get_scenario_full_name(scenario_name: str, checkpoint: str = "") -> str:
     """
     Construct the full name of a scenario with contains the name of the scenario

--- a/mxops/data/path_versions/v0_1_0.py
+++ b/mxops/data/path_versions/v0_1_0.py
@@ -1,7 +1,14 @@
 """
 author: Etienne Wallet
 
-This module (input/output) contains the functions to load and write contracts data
+This module contains the classes and the functions used to manage
+the data for the data model version 1.0.0
+
+General structure
+mxops
+└── <network>
+        └── <scenario_name><sep><checkpoint_name>.json
+
 """
 
 import os
@@ -13,28 +20,10 @@ from appdirs import AppDirs
 
 from mxops.config.config import Config
 from mxops.enums import NetworkEnum
-from mxops.utils.logger import get_logger
 
-
-LOGGER = get_logger("data-IO")
+VERSION = "v0.1.0"
+VERSION_AS_PATH = "v0_1_0"
 CHECKPOINT_SEP = "___CHECKPOINT___"
-
-
-def get_scenario_full_name(scenario_name: str, checkpoint: str = "") -> str:
-    """
-    Construct the full name of a scenario with contains the name of the scenario
-    and potentially the checkpoint separator and the checkpoint
-
-    :param scenario_name: name of the scenario
-    :type scenario_name: str
-    :param checkpoint: name of the checkpoint, defaults to ""
-    :type checkpoint: str, optional
-    :return: full name of the scenario
-    :rtype: str
-    """
-    if checkpoint == "":
-        return scenario_name
-    return f"{scenario_name}{CHECKPOINT_SEP}{checkpoint}"
 
 
 def get_data_path() -> Path:
@@ -57,6 +46,23 @@ def get_data_path() -> Path:
         return Path(data_path_config)
     app_dirs = AppDirs("mxops", "Catenscia")
     return Path(app_dirs.user_data_dir)
+
+
+def get_scenario_full_name(scenario_name: str, checkpoint: str = "") -> str:
+    """
+    Construct the full name of a scenario with contains the name of the scenario
+    and potentially the checkpoint separator and the checkpoint
+
+    :param scenario_name: name of the scenario
+    :type scenario_name: str
+    :param checkpoint: name of the checkpoint, defaults to ""
+    :type checkpoint: str, optional
+    :return: full name of the scenario
+    :rtype: str
+    """
+    if checkpoint == "":
+        return scenario_name
+    return f"{scenario_name}{CHECKPOINT_SEP}{checkpoint}"
 
 
 def initialize_data_folder():
@@ -156,6 +162,3 @@ def get_tx_file_path(contract_bech32_address: str) -> Path:
         / "transactions"
         / f"{contract_bech32_address}_txs.json"
     )
-
-
-LOGGER.debug(f"MxOps app directory is located at {get_data_path()}")

--- a/mxops/data/path_versions/v0_1_0.py
+++ b/mxops/data/path_versions/v0_1_0.py
@@ -22,7 +22,6 @@ from mxops.config.config import Config
 from mxops.enums import NetworkEnum
 
 VERSION = "v0.1.0"
-VERSION_AS_PATH = "v0_1_0"
 CHECKPOINT_SEP = "___CHECKPOINT___"
 
 

--- a/mxops/data/path_versions/v1_0_0.py
+++ b/mxops/data/path_versions/v1_0_0.py
@@ -1,0 +1,221 @@
+"""
+author: Etienne Wallet
+
+This module contains the classes and the functions used to manage
+the data for the data model version 1.0.0
+
+General structure
+mxops
+└── <data_version>
+    └── <network>
+        └── scenarios
+            └── <scenario_name>
+                ├── logs
+                ├── checkpoints
+                │   └── <checkpoint_name>
+                │       ├── abis
+                │       └── data.json
+                └── current
+                    ├── abis
+                    └── data.json
+
+"""
+
+import os
+from pathlib import Path
+import platform
+
+from appdirs import AppDirs
+
+from mxops.config.config import Config
+
+VERSION = "v1.0.0"
+VERSION_AS_PATH = "v1_0_0"
+
+
+def get_mxops_data_path() -> Path:
+    """
+    Return the folder path where to store the data created by this project.
+    Is defined in first instance by the value 'DATA_PATH' from the config
+    If this value is 'None' or '', a folder will be created in the App Dir
+    It uses the library appdirs to follow the conventions
+    across multi OS(MAc, Linux, Windows)
+    https://pypi.org/project/appdirs/
+
+    :return: path of the folder to use for data saving
+    :rtype: Path
+    """
+    if platform.system() == "Linux":  # handle snap issues
+        os.environ["XDG_DATA_HOME"] = os.path.expanduser("~/.local/share")
+    config = Config.get_config()
+    data_path_config = config.get("DATA_PATH")
+    if data_path_config not in ("None", ""):
+        data_path = Path(data_path_config)
+    else:
+        app_dirs = AppDirs("mxops", "Catenscia")
+        data_path = Path(app_dirs.user_data_dir)
+    return data_path / VERSION_AS_PATH
+
+
+def get_root_scenario_data_path(scenario_name: str) -> Path:
+    """
+    Return the root path for a scenario data, where all data
+    (current, checkpoints, logs) will be saved
+
+    :param scenario_name: name of the scenario
+    :type scenario_name: str
+    :return: path to the root scenario folder
+    :rtype: Path
+    """
+    mxops_data_path = get_mxops_data_path()
+    network = Config.get_config().get_network()
+    return mxops_data_path / network.name / "scenarios" / scenario_name
+
+
+def get_scenario_current_path(scenario_name: str) -> Path:
+    """
+    Return the path of the folder where the data related to the contracts, the tokens,
+    the saved values or the abis are written
+
+    :param scenario_name: name of the scenario
+    :type scenario_name: str
+    :return: folder path
+    :rtype: Path
+    """
+    root_scenario_path = get_root_scenario_data_path(scenario_name)
+    return root_scenario_path / "current"
+
+
+def get_scenario_current_data_path(scenario_name: str) -> Path:
+    """
+    Return the path of the file where the data related to the contracts, the tokens
+    or the saved values are written
+
+    :param scenario_name: name of the scenario
+    :type scenario_name: str
+    :return: file path
+    :rtype: Path
+    """
+    return get_scenario_current_path(scenario_name) / "data.json"
+
+
+def get_scenario_current_abis_path(scenario_name: str) -> Path:
+    """
+    Return the path of the folder where the abis related to
+    the contracts of the scenario are saved
+
+    :param scenario_name: name of the scenario
+    :type scenario_name: str
+    :return: folder path
+    :rtype: Path
+    """
+    return get_scenario_current_path(scenario_name) / "abis"
+
+
+def get_contract_abi_file_path(scenario_name: str, contract_id: str) -> Path:
+    """
+    Return the file path for a contract abi in the current data of a scenario
+
+    :param scenario_name: name of the scenario
+    :type scenario_name: str
+    :param contract_id: unique id of the contract
+    :type contract_id: str
+    :return: folder path
+    :rtype: Path
+    """
+    folder_path = get_scenario_current_path(scenario_name) / "abis"
+    return folder_path / f"{contract_id}.abi.json"
+
+
+def get_scenario_checkpoint_path(scenario_name: str, checkpoint_name: str) -> Path:
+    """
+    Return the path of the folder where a checkpoint of scenario data has been saved.
+    (abis, contracts data, tokens data ...)
+
+    :param scenario_name: name of the scenario
+    :type scenario_name: str
+    :param scenario_name: name of the checkpoint
+    :type scenario_name: str
+    :return: folder path
+    :rtype: Path
+    """
+    root_scenario_path = get_root_scenario_data_path(scenario_name)
+    return root_scenario_path / "checkpoints" / checkpoint_name
+
+
+def get_scenario_checkpoint_data_path(scenario_name: str, checkpoint_name: str) -> Path:
+    """
+    Return the checkpoint path of the file where the data related to the contracts,
+    the tokens or the saved values are written
+
+    :param scenario_name: name of the scenario
+    :type scenario_name: str
+    :param scenario_name: name of the checkpoint
+    :type scenario_name: str
+    :return: file path
+    :rtype: Path
+    """
+    return get_scenario_checkpoint_path(scenario_name, checkpoint_name) / "data.json"
+
+
+def get_scenario_logs_folder(scenario_name: str) -> Path:
+    """
+    Return the folder path where to save all execution logs
+    for a scenario
+
+    :param scenario_name: name of the scenario
+    :type scenario_name: str
+    :return: logs folder path
+    :rtype: Path
+    """
+    root_scenario_path = get_root_scenario_data_path(scenario_name)
+    return root_scenario_path / "logs"
+
+
+def get_all_scenarios_names() -> list[str]:
+    """
+    Return all the scenarios names that have locally saved data in the current network
+
+    :return: list of scenario names
+    :rtype: list[str]
+    """
+    scenarios_folder = get_root_scenario_data_path("fake_scenario").parent
+    try:
+        elements = os.listdir(scenarios_folder)
+    except FileNotFoundError:
+        return []
+
+    return [e for e in elements if (scenarios_folder / e).is_dir()]
+
+
+def get_all_checkpoints_names(scenario_name: str) -> list[str]:
+    """
+    Return all the existing checkpoints for a given scenario
+
+    :param scenario_name: name of the scenario
+    :type scenario_name: str
+    :return: list of the existing checkpoints
+    :rtype: list[str]
+    """
+    checkpoints_folder = get_scenario_checkpoint_path(
+        scenario_name, "checkpoint"
+    ).parent
+    try:
+        elements = os.listdir(checkpoints_folder)
+    except FileNotFoundError:
+        return []
+
+    return [e for e in elements if (checkpoints_folder / e).is_dir()]
+
+
+def does_scenario_exist(scenario_name: str) -> bool:
+    """
+    Check the data saved locally to tell if the provided scenario already exists
+
+    :param scenario_name: scenario to look for
+    :type scenario_name: str
+    :return: if the scenario exists
+    :rtype: bool
+    """
+    scenario_root_path = get_root_scenario_data_path(scenario_name)
+    return scenario_root_path.exists()

--- a/mxops/data/path_versions/v1_0_0.py
+++ b/mxops/data/path_versions/v1_0_0.py
@@ -28,9 +28,9 @@ import platform
 from appdirs import AppDirs
 
 from mxops.config.config import Config
+from mxops.data.path_versions.msc import version_name_to_version_path_name
 
 VERSION = "v1.0.0"
-VERSION_AS_PATH = "v1_0_0"
 
 
 def get_mxops_data_path() -> Path:
@@ -54,7 +54,7 @@ def get_mxops_data_path() -> Path:
     else:
         app_dirs = AppDirs("mxops", "Catenscia")
         data_path = Path(app_dirs.user_data_dir)
-    return data_path / VERSION_AS_PATH
+    return data_path / version_name_to_version_path_name(VERSION)
 
 
 def get_root_scenario_data_path(scenario_name: str) -> Path:

--- a/mxops/data/path_versions/v1_0_0.py
+++ b/mxops/data/path_versions/v1_0_0.py
@@ -57,6 +57,31 @@ def get_mxops_data_path() -> Path:
     return data_path / version_name_to_version_path_name(VERSION)
 
 
+def is_current_saved_version() -> bool:
+    """
+    Check if the current data version saved is the v1.0.0
+
+    :return: version number
+    :rtype: str
+    """
+    file_path = get_mxops_data_path().parent / "VERSION"
+    if not file_path.exists():
+        return False
+    saved_version = file_path.read_text()
+    return saved_version == VERSION
+
+
+def register_as_current() -> bool:
+    """
+    Check if the current data version saved is the v1.0.0
+
+    :return: version number
+    :rtype: str
+    """
+    file_path = get_mxops_data_path().parent / "VERSION"
+    file_path.write_text(VERSION)
+
+
 def get_root_scenario_data_path(scenario_name: str) -> Path:
     """
     Return the root path for a scenario data, where all data
@@ -156,6 +181,25 @@ def get_scenario_checkpoint_data_path(scenario_name: str, checkpoint_name: str) 
     :rtype: Path
     """
     return get_scenario_checkpoint_path(scenario_name, checkpoint_name) / "data.json"
+
+
+def get_checkpoint_contract_abi_file_path(
+    scenario_name: str, checkpoint_name: str, contract_id: str
+) -> Path:
+    """
+    Return the file path for a contract abi in the checkpoint data of a scenario
+
+    :param scenario_name: name of the scenario
+    :type scenario_name: str
+    :param scenario_name: name of the checkpoint
+    :type scenario_name: str
+    :param contract_id: unique id of the contract
+    :type contract_id: str
+    :return: folder path
+    :rtype: Path
+    """
+    folder_path = get_scenario_checkpoint_path(scenario_name, checkpoint_name) / "abis"
+    return folder_path / f"{contract_id}.abi.json"
 
 
 def get_scenario_logs_folder(scenario_name: str) -> Path:

--- a/mxops/errors.py
+++ b/mxops/errors.py
@@ -89,7 +89,17 @@ class UnloadedScenario(Exception):
 
 class UnknownContract(Exception):
     """
-    To be raised when a specified contract is not found is a scenario
+    To be raised when a specified contract is not found in a scenario
+    """
+
+    def __init__(self, scenario_name: str, contract_id: str) -> None:
+        message = f"Contract {contract_id} is unkown in " f"scenario {scenario_name}"
+        super().__init__(message)
+
+
+class UnknownAbiContract(Exception):
+    """
+    To be raised when the abi of a specified contract is not found in a scenario
     """
 
     def __init__(self, scenario_name: str, contract_id: str) -> None:
@@ -119,7 +129,7 @@ class ContractIdAlreadyExists(Exception):
 
 class UnknownToken(Exception):
     """
-    To be raised when a specified token is not found is a scenario
+    To be raised when a specified token is not found in a scenario
     """
 
     def __init__(self, scenario_name: str, token_name: str) -> None:
@@ -139,7 +149,7 @@ class TokenNameAlreadyExists(Exception):
 
 class UnknownRootName(Exception):
     """
-    To be raised when a specified root name is not found is a scenario
+    To be raised when a specified root name is not found in a scenario
     """
 
     def __init__(self, scenario_name: str, root_name: str) -> None:

--- a/mxops/execution/cli.py
+++ b/mxops/execution/cli.py
@@ -8,7 +8,6 @@ from argparse import _SubParsersAction, Namespace
 import os
 from pathlib import Path
 from mxops.config.config import Config
-from mxops.data import path
 from mxops.data.execution_data import ScenarioData, delete_scenario_data
 
 from mxops.enums import parse_network_enum
@@ -70,7 +69,6 @@ def execute_cli(args: Namespace):
     if args.command != "execute":
         raise ValueError(f"Command execute was expected, found {args.command}")
 
-    path.initialize_data_folder()
     Config.set_network(args.network)
 
     if args.clean:

--- a/mxops/execution/scene.py
+++ b/mxops/execution/scene.py
@@ -10,7 +10,6 @@ from pathlib import Path
 import re
 from typing import Dict, List, Union
 
-from mxpyserializer.abi_serializer import AbiSerializer
 import yaml
 
 from mxops.config.config import Config
@@ -139,20 +138,18 @@ def execute_scene(scene_path: Path):
         if isinstance(contract_data, str):
             contract_data = {"address": contract_data}
         address = contract_data["address"]
-        try:
-            serializer = AbiSerializer.from_abi(Path(contract_data["abi_path"]))
-        except KeyError:
-            serializer = None
+        if "abi_path" in contract_data:
+            scenario_data.set_contract_abi_from_source(
+                contract_id, Path(contract_data["abi_path"])
+            )
         try:
             scenario_data.set_contract_value(contract_id, "address", address)
-            scenario_data.contracts_data[contract_id].serializer = serializer
         except errors.UnknownContract:
             # otherwise create the contract data
             scenario_data.add_contract_data(
                 ExternalContractData(
                     contract_id=contract_id,
                     address=address,
-                    serializer=serializer,
                     saved_values={},
                 )
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mxops"
-version = "3.0.0-dev19"
+version = "3.0.0-dev110"
 authors = [
   {name="Etienne Wallet"},
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.0-dev19
+current_version = 3.0.0-dev110
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<release>\w+)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}{build}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,6 @@ from mxops.data.execution_data import (
     TokenData,
     delete_scenario_data,
 )
-from mxops.data.path import initialize_data_folder
 from mxops.enums import NetworkEnum, TokenTypeEnum
 from mxops.execution.account import AccountsManager
 
@@ -20,6 +19,7 @@ from mxops.execution.account import AccountsManager
 @pytest.fixture(scope="session", autouse=True)
 def network():
     Config.set_network(NetworkEnum.LOCAL)
+    Config.get_config().set_option("DATA_PATH", "./tests/mxops_data")
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -52,8 +52,7 @@ def test_data_folder_path():
 
 
 @pytest.fixture(scope="session", autouse=True)
-def scenario_data():
-    initialize_data_folder()
+def scenario_data(network):  # must be executed after the network fixture
     ScenarioData.create_scenario("pytest_scenario")
     contract_id = "my_test_contract"
     address = "erd1qqqqqqqqqqqqqpgqdmq43snzxutandvqefxgj89r6fh528v9dwnswvgq9t"
@@ -63,7 +62,6 @@ def scenario_data():
         InternalContractData(
             contract_id=contract_id,
             address=address,
-            serializer=None,
             wasm_hash=wasm_hash,
             deploy_time=1,
             last_upgrade_time=1,

--- a/tests/data/migrations/reconstructed.abi.json
+++ b/tests/data/migrations/reconstructed.abi.json
@@ -1,0 +1,522 @@
+{
+    "name": "data-store",
+    "constructor": {
+        "inputs": [
+            {
+                "name": "my_enum",
+                "type": "EnumWithEverything"
+            },
+            {
+                "name": "my_u32",
+                "type": "u32"
+            },
+            {
+                "name": "my_i8",
+                "type": "i8"
+            }
+        ],
+        "outputs": []
+    },
+    "upgradeConstructor": {
+        "inputs": [
+            {
+                "name": "my_biguint",
+                "type": "BigUint"
+            },
+            {
+                "name": "my_bigint",
+                "type": "BigInt"
+            }
+        ],
+        "outputs": []
+    },
+    "endpoints": [
+        {
+            "name": "my_usize",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "u32"
+                }
+            ]
+        },
+        {
+            "name": "my_u8",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "my_u16",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "my_u32",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "u32"
+                }
+            ]
+        },
+        {
+            "name": "my_u64",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "u64"
+                }
+            ]
+        },
+        {
+            "name": "my_isize",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "my_i8",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "i8"
+                }
+            ]
+        },
+        {
+            "name": "my_i16",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "i16"
+                }
+            ]
+        },
+        {
+            "name": "my_i32",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "my_i64",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "i64"
+                }
+            ]
+        },
+        {
+            "name": "my_token_identifier",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "TokenIdentifier"
+                }
+            ]
+        },
+        {
+            "name": "my_managed_address",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "Address"
+                }
+            ]
+        },
+        {
+            "name": "my_biguint",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "BigUint"
+                }
+            ]
+        },
+        {
+            "name": "my_bigint",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "BigInt"
+                }
+            ]
+        },
+        {
+            "name": "my_option_biguint",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "Option<BigUint>"
+                }
+            ]
+        },
+        {
+            "name": "my_vec_biguint",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "variadic<BigUint>",
+                    "multi_result": true
+                }
+            ]
+        },
+        {
+            "name": "my_enum_with_everything",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "EnumWithEverything"
+                }
+            ]
+        },
+        {
+            "name": "view_optional_1",
+            "mutability": "readonly",
+            "inputs": [
+                {
+                    "name": "my_optional",
+                    "type": "optional<bool>",
+                    "multi_arg": true
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "optional<bool>",
+                    "multi_result": true
+                }
+            ]
+        },
+        {
+            "name": "get_init_params",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "EnumWithEverything"
+                },
+                {
+                    "type": "u32"
+                },
+                {
+                    "type": "i8"
+                }
+            ]
+        },
+        {
+            "name": "get_upgrade_params",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "tuple<BigUint,BigInt>"
+                }
+            ]
+        },
+        {
+            "name": "test_1",
+            "mutability": "mutable",
+            "inputs": [
+                {
+                    "name": "my_option_biguint",
+                    "type": "Option<BigUint>"
+                },
+                {
+                    "name": "my_optional_token_identifier",
+                    "type": "optional<TokenIdentifier>",
+                    "multi_arg": true
+                }
+            ],
+            "outputs": []
+        },
+        {
+            "name": "test_2",
+            "mutability": "mutable",
+            "inputs": [
+                {
+                    "name": "my_managed_address",
+                    "type": "Address"
+                },
+                {
+                    "name": "my_optional_token_identifier",
+                    "type": "optional<TokenIdentifier>",
+                    "multi_arg": true
+                }
+            ],
+            "outputs": []
+        },
+        {
+            "name": "get_test_2_params",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "tuple<Address,TokenIdentifier>"
+                }
+            ]
+        },
+        {
+            "name": "test_3",
+            "mutability": "mutable",
+            "inputs": [
+                {
+                    "name": "my_isize",
+                    "type": "i32"
+                },
+                {
+                    "name": "biguints",
+                    "type": "variadic<BigUint>",
+                    "multi_arg": true
+                }
+            ],
+            "outputs": []
+        },
+        {
+            "name": "get_test_3_params",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "i32"
+                },
+                {
+                    "type": "variadic<BigUint>",
+                    "multi_result": true
+                }
+            ]
+        },
+        {
+            "name": "test_4",
+            "mutability": "mutable",
+            "inputs": [
+                {
+                    "name": "biguints",
+                    "type": "List<BigUint>"
+                }
+            ],
+            "outputs": []
+        },
+        {
+            "name": "get_test_4_params",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "List<BigUint>"
+                }
+            ]
+        },
+        {
+            "name": "view_test_1",
+            "mutability": "readonly",
+            "inputs": [
+                {
+                    "name": "a",
+                    "type": "DayOfWeek"
+                },
+                {
+                    "name": "b",
+                    "type": "DayOfWeek"
+                },
+                {
+                    "name": "c",
+                    "type": "EnumWithEverything"
+                },
+                {
+                    "name": "d",
+                    "type": "EnumWithEverything"
+                },
+                {
+                    "name": "e",
+                    "type": "EnumWithEverything"
+                },
+                {
+                    "name": "f",
+                    "type": "EnumWithEverything"
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "DayOfWeek"
+                },
+                {
+                    "type": "DayOfWeek"
+                },
+                {
+                    "type": "EnumWithEverything"
+                },
+                {
+                    "type": "EnumWithEverything"
+                },
+                {
+                    "type": "EnumWithEverything"
+                },
+                {
+                    "type": "EnumWithEverything"
+                }
+            ]
+        },
+        {
+            "name": "view_test_2",
+            "mutability": "readonly",
+            "inputs": [
+                {
+                    "name": "payments",
+                    "type": "variadic<EsdtTokenPayment>",
+                    "multi_arg": true
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "variadic<EsdtTokenPayment>",
+                    "multi_result": true
+                }
+            ]
+        }
+    ],
+    "esdtAttributes": [],
+    "hasCallback": false,
+    "types": {
+        "DayOfWeek": {
+            "type": "enum",
+            "variants": [
+                {
+                    "name": "Monday",
+                    "discriminant": 0
+                },
+                {
+                    "name": "Tuesday",
+                    "discriminant": 1
+                },
+                {
+                    "name": "Wednesday",
+                    "discriminant": 2
+                },
+                {
+                    "name": "Thursday",
+                    "discriminant": 3
+                },
+                {
+                    "name": "Friday",
+                    "discriminant": 4
+                },
+                {
+                    "name": "Saturday",
+                    "discriminant": 5
+                },
+                {
+                    "name": "Sunday",
+                    "discriminant": 6
+                }
+            ]
+        },
+        "EnumWithEverything": {
+            "type": "enum",
+            "variants": [
+                {
+                    "name": "Default",
+                    "discriminant": 0
+                },
+                {
+                    "name": "Today",
+                    "discriminant": 1,
+                    "fields": [
+                        {
+                            "name": "0",
+                            "type": "DayOfWeek"
+                        }
+                    ]
+                },
+                {
+                    "name": "Write",
+                    "discriminant": 2,
+                    "fields": [
+                        {
+                            "name": "0",
+                            "type": "bytes"
+                        },
+                        {
+                            "name": "1",
+                            "type": "u16"
+                        }
+                    ]
+                },
+                {
+                    "name": "Struct",
+                    "discriminant": 3,
+                    "fields": [
+                        {
+                            "name": "int",
+                            "type": "u16"
+                        },
+                        {
+                            "name": "seq",
+                            "type": "bytes"
+                        },
+                        {
+                            "name": "another_byte",
+                            "type": "u8"
+                        },
+                        {
+                            "name": "uint_32",
+                            "type": "u32"
+                        },
+                        {
+                            "name": "uint_64",
+                            "type": "u64"
+                        }
+                    ]
+                }
+            ]
+        },
+        "EsdtTokenPayment": {
+            "type": "struct",
+            "fields": [
+                {
+                    "name": "token_identifier",
+                    "type": "TokenIdentifier"
+                },
+                {
+                    "name": "token_nonce",
+                    "type": "u64"
+                },
+                {
+                    "name": "amount",
+                    "type": "BigUint"
+                }
+            ]
+        }
+    }
+}

--- a/tests/data/migrations/v0_1_0.json
+++ b/tests/data/migrations/v0_1_0.json
@@ -1,0 +1,751 @@
+{
+    "saved_values": {
+        "marie": {
+            "address": "erd1tpkdh44yyyx5zwuukmdvry2u7uajgc3l5gf04e45gepfprwchyrswjw5vs"
+        },
+        "emmanuel": {
+            "address": "erd1yy995sn9drrlj7qvzgpcyfgexl7kh9u33l3zqp5np20vw5p2jmwq7s4ark"
+        },
+        "fran\u00e7ois": {
+            "address": "erd1gyqgmmxmg9fttvug4dx5hs4ggewgsaz2al4zankfkr0x8jyd3h9s2est3m"
+        },
+        "thomas": {
+            "address": "erd1ngpjmxuzgvnsdxesy66e354sk77ce22vv8augpms6lx2vyjq3dqssfwyqu"
+        },
+        "paul": {
+            "address": "erd1u07h7vlhktwasayzt6uwpaq6nzkdyhf0d9kpxeye8n9mqztrmmwqfhruwv"
+        },
+        "marthe": {
+            "address": "erd10xth2hqqxnj2nckt0fqcq004ns2wckews6ygu6nu5tp9cwrxnu6sy4qlxt"
+        },
+        "marc": {
+            "address": "erd1g9ysagkr3aev8lxudcxl8j5nk77uy0aa3y26aaxhhu55k4dqccaqt9vvwp"
+        },
+        "jacques": {
+            "address": "erd1gvclvcfp7y586cfyg9ammcw39ld3cltqqkeu7lz86ws5fredufssjs6rlr"
+        },
+        "pierre": {
+            "address": "erd156ph6mcjqv5vzwjq9fctalg9kvk27y9sgs23sugltsy7sa23xw4svyhr2w"
+        },
+        "jean": {
+            "address": "erd1czt3wrd9qfsgqyfrgk9p48ug38s7qnlzqvvaquqcaz07wlk0dwnspwn7x0"
+        },
+        "user_wallets": [
+            "emmanuel",
+            "fran\u00e7ois",
+            "jacques",
+            "jean",
+            "marc",
+            "marie",
+            "marthe",
+            "paul",
+            "pierre",
+            "thomas"
+        ]
+    },
+    "name": "integration_test_data_store",
+    "network": "chain-simulator",
+    "creation_time": 1734282389,
+    "last_update_time": 1734282390,
+    "contracts_data": {
+        "data-store": {
+            "saved_values": {
+                "init_params": [
+                    {
+                        "name": "Default",
+                        "discriminant": 0,
+                        "values": null
+                    },
+                    123455,
+                    -3
+                ],
+                "init_params_2": {
+                    "a": 0,
+                    "b": 123455,
+                    "c": -3
+                },
+                "upgrade_params": [
+                    1000000000000000000,
+                    -100000000000000000
+                ],
+                "my_option_biguint": 123987,
+                "my_token_identifier": "",
+                "test_2_params": [
+                    "erd1qqqqqqqqqqqqqpgqf48ydzn8shr8mnmrvydq2fn9v2afzd3c4fvsk4wglm",
+                    "WEGLD-abcdef"
+                ],
+                "test_3_params": [
+                    -3,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                ],
+                "my_vec_biguint": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6
+                ],
+                "test_4_params": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6
+                ],
+                "view_test_1_returns": [
+                    {
+                        "name": "Monday",
+                        "discriminant": 0,
+                        "values": null
+                    },
+                    {
+                        "name": "Sunday",
+                        "discriminant": 6,
+                        "values": null
+                    },
+                    {
+                        "name": "Default",
+                        "discriminant": 0,
+                        "values": null
+                    },
+                    {
+                        "name": "Today",
+                        "discriminant": 1,
+                        "values": [
+                            {
+                                "name": "Tuesday",
+                                "discriminant": 1,
+                                "values": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "Write",
+                        "discriminant": 2,
+                        "values": [
+                            "bytes:AQIECA==",
+                            14
+                        ]
+                    },
+                    {
+                        "name": "Struct",
+                        "discriminant": 3,
+                        "values": [
+                            8,
+                            "bytes:CS0=",
+                            0,
+                            789484,
+                            485
+                        ]
+                    }
+                ],
+                "view_test_2_returns": [
+                    {
+                        "token_identifier": "WEGLD-abcdef",
+                        "token_nonce": 0,
+                        "amount": 89784651
+                    },
+                    {
+                        "token_identifier": "MEX-abcdef",
+                        "token_nonce": 0,
+                        "amount": 184791484
+                    }
+                ]
+            },
+            "contract_id": "data-store",
+            "address": "erd1qqqqqqqqqqqqqpgq5d4kvm8mdznek3e3ty6npluuneuhxsxajmwqvya7p8",
+            "serializer": {
+                "endpoints": {
+                    "my_usize": {
+                        "name": "my_usize",
+                        "mutability": "readonly",
+                        "inputs": [],
+                        "outputs": [
+                            {
+                                "type": "u32"
+                            }
+                        ],
+                        "docs": []
+                    },
+                    "my_u8": {
+                        "name": "my_u8",
+                        "mutability": "readonly",
+                        "inputs": [],
+                        "outputs": [
+                            {
+                                "type": "u8"
+                            }
+                        ],
+                        "docs": []
+                    },
+                    "my_u16": {
+                        "name": "my_u16",
+                        "mutability": "readonly",
+                        "inputs": [],
+                        "outputs": [
+                            {
+                                "type": "u16"
+                            }
+                        ],
+                        "docs": []
+                    },
+                    "my_u32": {
+                        "name": "my_u32",
+                        "mutability": "readonly",
+                        "inputs": [],
+                        "outputs": [
+                            {
+                                "type": "u32"
+                            }
+                        ],
+                        "docs": []
+                    },
+                    "my_u64": {
+                        "name": "my_u64",
+                        "mutability": "readonly",
+                        "inputs": [],
+                        "outputs": [
+                            {
+                                "type": "u64"
+                            }
+                        ],
+                        "docs": []
+                    },
+                    "my_isize": {
+                        "name": "my_isize",
+                        "mutability": "readonly",
+                        "inputs": [],
+                        "outputs": [
+                            {
+                                "type": "i32"
+                            }
+                        ],
+                        "docs": []
+                    },
+                    "my_i8": {
+                        "name": "my_i8",
+                        "mutability": "readonly",
+                        "inputs": [],
+                        "outputs": [
+                            {
+                                "type": "i8"
+                            }
+                        ],
+                        "docs": []
+                    },
+                    "my_i16": {
+                        "name": "my_i16",
+                        "mutability": "readonly",
+                        "inputs": [],
+                        "outputs": [
+                            {
+                                "type": "i16"
+                            }
+                        ],
+                        "docs": []
+                    },
+                    "my_i32": {
+                        "name": "my_i32",
+                        "mutability": "readonly",
+                        "inputs": [],
+                        "outputs": [
+                            {
+                                "type": "i32"
+                            }
+                        ],
+                        "docs": []
+                    },
+                    "my_i64": {
+                        "name": "my_i64",
+                        "mutability": "readonly",
+                        "inputs": [],
+                        "outputs": [
+                            {
+                                "type": "i64"
+                            }
+                        ],
+                        "docs": []
+                    },
+                    "my_token_identifier": {
+                        "name": "my_token_identifier",
+                        "mutability": "readonly",
+                        "inputs": [],
+                        "outputs": [
+                            {
+                                "type": "TokenIdentifier"
+                            }
+                        ],
+                        "docs": []
+                    },
+                    "my_managed_address": {
+                        "name": "my_managed_address",
+                        "mutability": "readonly",
+                        "inputs": [],
+                        "outputs": [
+                            {
+                                "type": "Address"
+                            }
+                        ],
+                        "docs": []
+                    },
+                    "my_biguint": {
+                        "name": "my_biguint",
+                        "mutability": "readonly",
+                        "inputs": [],
+                        "outputs": [
+                            {
+                                "type": "BigUint"
+                            }
+                        ],
+                        "docs": []
+                    },
+                    "my_bigint": {
+                        "name": "my_bigint",
+                        "mutability": "readonly",
+                        "inputs": [],
+                        "outputs": [
+                            {
+                                "type": "BigInt"
+                            }
+                        ],
+                        "docs": []
+                    },
+                    "my_option_biguint": {
+                        "name": "my_option_biguint",
+                        "mutability": "readonly",
+                        "inputs": [],
+                        "outputs": [
+                            {
+                                "type": "Option<BigUint>"
+                            }
+                        ],
+                        "docs": []
+                    },
+                    "my_vec_biguint": {
+                        "name": "my_vec_biguint",
+                        "mutability": "readonly",
+                        "inputs": [],
+                        "outputs": [
+                            {
+                                "type": "variadic<BigUint>",
+                                "multi_result": true
+                            }
+                        ],
+                        "docs": []
+                    },
+                    "my_enum_with_everything": {
+                        "name": "my_enum_with_everything",
+                        "mutability": "readonly",
+                        "inputs": [],
+                        "outputs": [
+                            {
+                                "type": "EnumWithEverything"
+                            }
+                        ],
+                        "docs": []
+                    },
+                    "view_optional_1": {
+                        "name": "view_optional_1",
+                        "mutability": "readonly",
+                        "inputs": [
+                            {
+                                "name": "my_optional",
+                                "type": "optional<bool>",
+                                "multi_arg": true
+                            }
+                        ],
+                        "outputs": [
+                            {
+                                "type": "optional<bool>",
+                                "multi_result": true
+                            }
+                        ],
+                        "docs": []
+                    },
+                    "get_init_params": {
+                        "name": "get_init_params",
+                        "mutability": "readonly",
+                        "inputs": [],
+                        "outputs": [
+                            {
+                                "type": "EnumWithEverything"
+                            },
+                            {
+                                "type": "u32"
+                            },
+                            {
+                                "type": "i8"
+                            }
+                        ],
+                        "docs": []
+                    },
+                    "get_upgrade_params": {
+                        "name": "get_upgrade_params",
+                        "mutability": "readonly",
+                        "inputs": [],
+                        "outputs": [
+                            {
+                                "type": "tuple<BigUint,BigInt>"
+                            }
+                        ],
+                        "docs": []
+                    },
+                    "test_1": {
+                        "name": "test_1",
+                        "mutability": "mutable",
+                        "inputs": [
+                            {
+                                "name": "my_option_biguint",
+                                "type": "Option<BigUint>"
+                            },
+                            {
+                                "name": "my_optional_token_identifier",
+                                "type": "optional<TokenIdentifier>",
+                                "multi_arg": true
+                            }
+                        ],
+                        "outputs": [],
+                        "docs": []
+                    },
+                    "test_2": {
+                        "name": "test_2",
+                        "mutability": "mutable",
+                        "inputs": [
+                            {
+                                "name": "my_managed_address",
+                                "type": "Address"
+                            },
+                            {
+                                "name": "my_optional_token_identifier",
+                                "type": "optional<TokenIdentifier>",
+                                "multi_arg": true
+                            }
+                        ],
+                        "outputs": [],
+                        "docs": []
+                    },
+                    "get_test_2_params": {
+                        "name": "get_test_2_params",
+                        "mutability": "readonly",
+                        "inputs": [],
+                        "outputs": [
+                            {
+                                "type": "tuple<Address,TokenIdentifier>"
+                            }
+                        ],
+                        "docs": []
+                    },
+                    "test_3": {
+                        "name": "test_3",
+                        "mutability": "mutable",
+                        "inputs": [
+                            {
+                                "name": "my_isize",
+                                "type": "i32"
+                            },
+                            {
+                                "name": "biguints",
+                                "type": "variadic<BigUint>",
+                                "multi_arg": true
+                            }
+                        ],
+                        "outputs": [],
+                        "docs": []
+                    },
+                    "get_test_3_params": {
+                        "name": "get_test_3_params",
+                        "mutability": "readonly",
+                        "inputs": [],
+                        "outputs": [
+                            {
+                                "type": "i32"
+                            },
+                            {
+                                "type": "variadic<BigUint>",
+                                "multi_result": true
+                            }
+                        ],
+                        "docs": []
+                    },
+                    "test_4": {
+                        "name": "test_4",
+                        "mutability": "mutable",
+                        "inputs": [
+                            {
+                                "name": "biguints",
+                                "type": "List<BigUint>"
+                            }
+                        ],
+                        "outputs": [],
+                        "docs": []
+                    },
+                    "get_test_4_params": {
+                        "name": "get_test_4_params",
+                        "mutability": "readonly",
+                        "inputs": [],
+                        "outputs": [
+                            {
+                                "type": "List<BigUint>"
+                            }
+                        ],
+                        "docs": []
+                    },
+                    "view_test_1": {
+                        "name": "view_test_1",
+                        "mutability": "readonly",
+                        "inputs": [
+                            {
+                                "name": "a",
+                                "type": "DayOfWeek"
+                            },
+                            {
+                                "name": "b",
+                                "type": "DayOfWeek"
+                            },
+                            {
+                                "name": "c",
+                                "type": "EnumWithEverything"
+                            },
+                            {
+                                "name": "d",
+                                "type": "EnumWithEverything"
+                            },
+                            {
+                                "name": "e",
+                                "type": "EnumWithEverything"
+                            },
+                            {
+                                "name": "f",
+                                "type": "EnumWithEverything"
+                            }
+                        ],
+                        "outputs": [
+                            {
+                                "type": "DayOfWeek"
+                            },
+                            {
+                                "type": "DayOfWeek"
+                            },
+                            {
+                                "type": "EnumWithEverything"
+                            },
+                            {
+                                "type": "EnumWithEverything"
+                            },
+                            {
+                                "type": "EnumWithEverything"
+                            },
+                            {
+                                "type": "EnumWithEverything"
+                            }
+                        ],
+                        "docs": []
+                    },
+                    "view_test_2": {
+                        "name": "view_test_2",
+                        "mutability": "readonly",
+                        "inputs": [
+                            {
+                                "name": "payments",
+                                "type": "variadic<EsdtTokenPayment>",
+                                "multi_arg": true
+                            }
+                        ],
+                        "outputs": [
+                            {
+                                "type": "variadic<EsdtTokenPayment>",
+                                "multi_result": true
+                            }
+                        ],
+                        "docs": []
+                    },
+                    "init": {
+                        "name": "init",
+                        "mutability": "mutable",
+                        "inputs": [
+                            {
+                                "name": "my_enum",
+                                "type": "EnumWithEverything"
+                            },
+                            {
+                                "name": "my_u32",
+                                "type": "u32"
+                            },
+                            {
+                                "name": "my_i8",
+                                "type": "i8"
+                            }
+                        ],
+                        "outputs": [],
+                        "docs": []
+                    },
+                    "upgrade": {
+                        "name": "upgrade",
+                        "mutability": "mutable",
+                        "inputs": [
+                            {
+                                "name": "my_biguint",
+                                "type": "BigUint"
+                            },
+                            {
+                                "name": "my_bigint",
+                                "type": "BigInt"
+                            }
+                        ],
+                        "outputs": [],
+                        "docs": []
+                    }
+                },
+                "structs": {
+                    "EsdtTokenPayment": {
+                        "name": "EsdtTokenPayment",
+                        "fields": [
+                            {
+                                "name": "token_identifier",
+                                "type": "TokenIdentifier",
+                                "docs": []
+                            },
+                            {
+                                "name": "token_nonce",
+                                "type": "u64",
+                                "docs": []
+                            },
+                            {
+                                "name": "amount",
+                                "type": "BigUint",
+                                "docs": []
+                            }
+                        ],
+                        "docs": []
+                    }
+                },
+                "enums": {
+                    "DayOfWeek": {
+                        "name": "DayOfWeek",
+                        "variants": [
+                            {
+                                "name": "Monday",
+                                "discriminant": 0,
+                                "fields": []
+                            },
+                            {
+                                "name": "Tuesday",
+                                "discriminant": 1,
+                                "fields": []
+                            },
+                            {
+                                "name": "Wednesday",
+                                "discriminant": 2,
+                                "fields": []
+                            },
+                            {
+                                "name": "Thursday",
+                                "discriminant": 3,
+                                "fields": []
+                            },
+                            {
+                                "name": "Friday",
+                                "discriminant": 4,
+                                "fields": []
+                            },
+                            {
+                                "name": "Saturday",
+                                "discriminant": 5,
+                                "fields": []
+                            },
+                            {
+                                "name": "Sunday",
+                                "discriminant": 6,
+                                "fields": []
+                            }
+                        ],
+                        "docs": []
+                    },
+                    "EnumWithEverything": {
+                        "name": "EnumWithEverything",
+                        "variants": [
+                            {
+                                "name": "Default",
+                                "discriminant": 0,
+                                "fields": []
+                            },
+                            {
+                                "name": "Today",
+                                "discriminant": 1,
+                                "fields": [
+                                    {
+                                        "name": "0",
+                                        "type": "DayOfWeek",
+                                        "docs": []
+                                    }
+                                ]
+                            },
+                            {
+                                "name": "Write",
+                                "discriminant": 2,
+                                "fields": [
+                                    {
+                                        "name": "0",
+                                        "type": "bytes",
+                                        "docs": []
+                                    },
+                                    {
+                                        "name": "1",
+                                        "type": "u16",
+                                        "docs": []
+                                    }
+                                ]
+                            },
+                            {
+                                "name": "Struct",
+                                "discriminant": 3,
+                                "fields": [
+                                    {
+                                        "name": "int",
+                                        "type": "u16",
+                                        "docs": []
+                                    },
+                                    {
+                                        "name": "seq",
+                                        "type": "bytes",
+                                        "docs": []
+                                    },
+                                    {
+                                        "name": "another_byte",
+                                        "type": "u8",
+                                        "docs": []
+                                    },
+                                    {
+                                        "name": "uint_32",
+                                        "type": "u32",
+                                        "docs": []
+                                    },
+                                    {
+                                        "name": "uint_64",
+                                        "type": "u64",
+                                        "docs": []
+                                    }
+                                ]
+                            }
+                        ],
+                        "docs": []
+                    }
+                }
+            },
+            "wasm_hash": "45b70609707c56d046e6a5ec0990d9d7feb54000503fcc171f7153aa399dc224",
+            "deploy_time": 1734283186,
+            "last_upgrade_time": 1734283192,
+            "is_external": false
+        }
+    },
+    "tokens_data": {}
+}

--- a/tests/data/migrations/v1_0_0.json
+++ b/tests/data/migrations/v1_0_0.json
@@ -1,0 +1,173 @@
+{
+    "saved_values": {
+        "marie": {
+            "address": "erd1tpkdh44yyyx5zwuukmdvry2u7uajgc3l5gf04e45gepfprwchyrswjw5vs"
+        },
+        "emmanuel": {
+            "address": "erd1yy995sn9drrlj7qvzgpcyfgexl7kh9u33l3zqp5np20vw5p2jmwq7s4ark"
+        },
+        "fran\u00e7ois": {
+            "address": "erd1gyqgmmxmg9fttvug4dx5hs4ggewgsaz2al4zankfkr0x8jyd3h9s2est3m"
+        },
+        "thomas": {
+            "address": "erd1ngpjmxuzgvnsdxesy66e354sk77ce22vv8augpms6lx2vyjq3dqssfwyqu"
+        },
+        "paul": {
+            "address": "erd1u07h7vlhktwasayzt6uwpaq6nzkdyhf0d9kpxeye8n9mqztrmmwqfhruwv"
+        },
+        "marthe": {
+            "address": "erd10xth2hqqxnj2nckt0fqcq004ns2wckews6ygu6nu5tp9cwrxnu6sy4qlxt"
+        },
+        "marc": {
+            "address": "erd1g9ysagkr3aev8lxudcxl8j5nk77uy0aa3y26aaxhhu55k4dqccaqt9vvwp"
+        },
+        "jacques": {
+            "address": "erd1gvclvcfp7y586cfyg9ammcw39ld3cltqqkeu7lz86ws5fredufssjs6rlr"
+        },
+        "pierre": {
+            "address": "erd156ph6mcjqv5vzwjq9fctalg9kvk27y9sgs23sugltsy7sa23xw4svyhr2w"
+        },
+        "jean": {
+            "address": "erd1czt3wrd9qfsgqyfrgk9p48ug38s7qnlzqvvaquqcaz07wlk0dwnspwn7x0"
+        },
+        "user_wallets": [
+            "emmanuel",
+            "fran\u00e7ois",
+            "jacques",
+            "jean",
+            "marc",
+            "marie",
+            "marthe",
+            "paul",
+            "pierre",
+            "thomas"
+        ]
+    },
+    "name": "integration_test_data_store",
+    "network": "chain-simulator",
+    "creation_time": 1734282389,
+    "last_update_time": 1734282390,
+    "contracts_data": {
+        "data-store": {
+            "saved_values": {
+                "init_params": [
+                    {
+                        "name": "Default",
+                        "discriminant": 0,
+                        "values": null
+                    },
+                    123455,
+                    -3
+                ],
+                "init_params_2": {
+                    "a": 0,
+                    "b": 123455,
+                    "c": -3
+                },
+                "upgrade_params": [
+                    1000000000000000000,
+                    -100000000000000000
+                ],
+                "my_option_biguint": 123987,
+                "my_token_identifier": "",
+                "test_2_params": [
+                    "erd1qqqqqqqqqqqqqpgqf48ydzn8shr8mnmrvydq2fn9v2afzd3c4fvsk4wglm",
+                    "WEGLD-abcdef"
+                ],
+                "test_3_params": [
+                    -3,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                ],
+                "my_vec_biguint": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6
+                ],
+                "test_4_params": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6
+                ],
+                "view_test_1_returns": [
+                    {
+                        "name": "Monday",
+                        "discriminant": 0,
+                        "values": null
+                    },
+                    {
+                        "name": "Sunday",
+                        "discriminant": 6,
+                        "values": null
+                    },
+                    {
+                        "name": "Default",
+                        "discriminant": 0,
+                        "values": null
+                    },
+                    {
+                        "name": "Today",
+                        "discriminant": 1,
+                        "values": [
+                            {
+                                "name": "Tuesday",
+                                "discriminant": 1,
+                                "values": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "Write",
+                        "discriminant": 2,
+                        "values": [
+                            "bytes:AQIECA==",
+                            14
+                        ]
+                    },
+                    {
+                        "name": "Struct",
+                        "discriminant": 3,
+                        "values": [
+                            8,
+                            "bytes:CS0=",
+                            0,
+                            789484,
+                            485
+                        ]
+                    }
+                ],
+                "view_test_2_returns": [
+                    {
+                        "token_identifier": "WEGLD-abcdef",
+                        "token_nonce": 0,
+                        "amount": 89784651
+                    },
+                    {
+                        "token_identifier": "MEX-abcdef",
+                        "token_nonce": 0,
+                        "amount": 184791484
+                    }
+                ]
+            },
+            "contract_id": "data-store",
+            "address": "erd1qqqqqqqqqqqqqpgq5d4kvm8mdznek3e3ty6npluuneuhxsxajmwqvya7p8",
+            "wasm_hash": "45b70609707c56d046e6a5ec0990d9d7feb54000503fcc171f7153aa399dc224",
+            "deploy_time": 1734283186,
+            "last_upgrade_time": 1734283192,
+            "is_external": false
+        }
+    },
+    "tokens_data": {}
+}

--- a/tests/data/scenarios/scenario_D.json
+++ b/tests/data/scenarios/scenario_D.json
@@ -7,7 +7,6 @@
         "egld-ping-pong": {
             "contract_id": "egld-ping-pong",
             "address": "erd1qqqqqqqqqqqqqpgq0048vv3uk6l6cdreezpallvduy4qnfv2plcq74464k",
-            "serializer": null,
             "saved_values": {},
             "wasm_hash": "5ce403a4f73701481cc15b2378cdc5bce3e35fa215815aa5eb9104d9f7ab2451",
             "deploy_time": 1677134892,
@@ -17,7 +16,6 @@
         "wrapper": {
             "contract_id": "wrapper",
             "address": "erd1qqqqqqqqqqqqqpgqdmq43snzxutandvqefxgj89r6fh528v9dwnswvgq9t",
-            "serializer": null,
             "saved_values": {},
             "is_external": true
         }

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -123,7 +123,6 @@ def test_data_load_equality():
     contract_data = InternalContractData(
         contract_id="egld-ping-pong",
         address="erd1qqqqqqqqqqqqqpgqpxkd9qgyyxykq5l6d8v9zud99hpwh7l0plcq3dae77",
-        serializer=None,
         saved_values={"PingAmount": 1000000000000000000},
         wasm_hash="1383133d22b8be01c4dc6dfda448dbf0b70ba1acb348a50dd3224b9c8bb21757",
         deploy_time=1677261606,

--- a/tests/test_data_io.py
+++ b/tests/test_data_io.py
@@ -12,6 +12,7 @@ from mxops.data.execution_data import (
     TokenData,
     parse_value_key,
 )
+from mxops.data.migrations.v0_1_0__to__v1_0_0 import convert_scenario
 from mxops.enums import NetworkEnum, TokenTypeEnum
 
 
@@ -230,3 +231,26 @@ def test_io_unicity():
 
     # Then
     assert scenario_dict == raw_data
+
+
+def test_migration_v0_1_0_to_v1_0_0():
+    """
+    Test that a scenario file is correctly transformed from version v0.1.0
+    to v1.0.0
+    """
+    # Given
+    initial_scenario = json.loads(Path("tests/data/migrations/v0_1_0.json").read_text())
+
+    # When
+    result_scenario, abis = convert_scenario(initial_scenario)
+
+    # Then
+    expected_scenario = json.loads(
+        Path("tests/data/migrations/v1_0_0.json").read_text()
+    )
+    assert expected_scenario == result_scenario
+    assert len(abis) == 1
+    expected_abi = json.loads(
+        Path("tests/data/migrations/reconstructed.abi.json").read_text()
+    )
+    assert abis["data-store"] == expected_abi

--- a/tests/test_data_io.py
+++ b/tests/test_data_io.py
@@ -1,11 +1,8 @@
 import json
 from pathlib import Path
-import time
 from typing import Any, List
 
 import pytest
-
-from mxpyserializer.abi_serializer import AbiSerializer
 
 from mxops import errors
 from mxops.data.execution_data import (
@@ -41,7 +38,6 @@ def test_scenario_loading(scenario_path: Path):
         "egld-ping-pong": InternalContractData(
             contract_id="egld-ping-pong",
             address="erd1qqqqqqqqqqqqqpgq0048vv3uk6l6cdreezpallvduy4qnfv2plcq74464k",
-            serializer=None,
             saved_values={},
             wasm_hash=(
                 "5ce403a4f73701481cc15b2378cdc5bce3e35fa215815aa5eb9104d9f7ab2451"
@@ -234,44 +230,3 @@ def test_io_unicity():
 
     # Then
     assert scenario_dict == raw_data
-
-
-def test_abiserializer_io():
-    """
-    Test that an AbiSerializer object is correctly loaded from ABI, saved and reloaded
-    from Scenario data
-    """
-    # Given
-    current_timestamp = int(time.time())
-    scenario_data = _ScenarioData(
-        "__MXOPS_TEST_SCENARIO_ARBITRAGER_IO",
-        NetworkEnum.LOCAL,
-        current_timestamp,
-        current_timestamp,
-        {},
-    )
-    serializer = AbiSerializer.from_abi(Path("tests/data/abis/adder.abi.json"))
-    contract_name = "contract-test"
-    contract_data = InternalContractData(
-        contract_id=contract_name,
-        address="erd1qqqqqqqqqqqqqpgq0048vv3uk6l6cdreezpallvduy4qnfv2plcq74464k",
-        saved_values={},
-        wasm_hash="hash",
-        deploy_time=current_timestamp,
-        last_upgrade_time=current_timestamp,
-        serializer=serializer,
-    )
-    scenario_data.add_contract_data(contract_data)
-
-    # When
-    scenario_data_to_dict = scenario_data.to_dict()
-    reloaded_scenario_data = _ScenarioData.from_dict(scenario_data_to_dict)
-
-    # Then
-    assert isinstance(
-        reloaded_scenario_data.contracts_data[contract_name].serializer, AbiSerializer
-    )
-    assert (
-        reloaded_scenario_data.contracts_data[contract_name].to_dict()
-        == scenario_data.contracts_data[contract_name].to_dict()
-    )

--- a/tests/test_instantiate.py
+++ b/tests/test_instantiate.py
@@ -93,7 +93,8 @@ def test_abi_loading(test_data_folder_path: Path):
 
     # When
     execute_scene(scene_path)
-    serializer: AbiSerializer = scenario_data.get_contract_value("adder", "serializer")
+    contract_abi = scenario_data.get_contract_abi("adder")
+    serializer = AbiSerializer.from_abi_dict(contract_abi)
 
     # Then
     assert list(serializer.endpoints.keys()) == ["getSum", "upgrade", "add", "init"]


### PR DESCRIPTION
# Modified:
- mxops data is now saved in a versionned way (each version have a different path)
- chain-simulator is now the default chain for the data cli
- new data version to separate between the abis and mxops data


# Added:
- automated migration between legacy data (0.1.0) and this version (1.0.0)