### PR TITLE
Breaking/drop ledger account index

### DIFF
--- a/docs/source/dev_documentation/changelog.md
+++ b/docs/source/dev_documentation/changelog.md
@@ -36,6 +36,7 @@
 - 🚨 BREAKING CHANGE 🚨 OptionalValue are mandatory now (user must input "null")
 - 🚨 BREAKING CHANGE 🚨 Enums format has changed to use the one from the multiversx-sdk-py
 - 🚨 BREAKING CHANGE 🚨 MultiValueEncoded format has changed to use the one from the multiversx-sdk-py
+- 🚨 BREAKING CHANGE 🚨 ledger account index was dropped as it is not used by multiversx-sdk-py
 
 
 ## 2.2.0 - 2024-04-16

--- a/docs/source/user_documentation/scenes.md
+++ b/docs/source/user_documentation/scenes.md
@@ -38,7 +38,6 @@ accounts:
     pem_path: path/to/bom_pem
 
   - account_name: alice
-    ledger_account_index: 12
     ledger_address_index: 2
 
   - name: user_wallets

--- a/mxops/execution/account.py
+++ b/mxops/execution/account.py
@@ -54,7 +54,6 @@ class AccountsManager:
         cls,
         account_name: str,
         pem_path: str | Path | None = None,
-        ledger_account_index: int | None = None,
         ledger_address_index: int | None = None,
     ):
         """
@@ -66,8 +65,6 @@ class AccountsManager:
         :type account_name: str
         :param pem_path: string path to the PEM file, defaults to None
         :type pem_path: Optional[Path], optional
-        :param ledger_account_index: index of the ledger account, defaults to None
-        :type ledger_account_index: Optional[int], optional
         :param ledger_address_index: index of the ledger address, defaults to None
         :type ledger_address_index: Optional[int], optional
         """
@@ -75,7 +72,7 @@ class AccountsManager:
             pem_path = Path(pem_path)
         if isinstance(pem_path, Path):
             account = Account.new_from_pem(pem_path)
-        elif ledger_account_index is not None and ledger_address_index is not None:
+        elif ledger_address_index is not None:
             account = LedgerAccount(ledger_address_index)
         else:
             raise ValueError(f"{account_name} is not correctly configured")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mxops"
-version = "3.0.0-dev24"
+version = "3.0.0-dev25"
 authors = [
   {name="Etienne Wallet"},
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.0-dev24
+current_version = 3.0.0-dev25
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<release>[^-0-9]+)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}{build}


### PR DESCRIPTION
# Breaking
- account argument `ledger_account_index` was droped as it is not used by the multiversx-sdk-py