### PR TITLE
Feat/save new wallets address

### DIFF
--- a/mxops/execution/smart_values/utils.py
+++ b/mxops/execution/smart_values/utils.py
@@ -212,7 +212,7 @@ def get_address_instance(address_str: str) -> Address:
 
     # finally try to see if it designates a defined account
     try:
-        account = AccountsManager.get_account(evaluated_address_str)
+        account = AccountsManager.get_account(address_str)
         return account.address
     except errors.UnknownAccount:
         pass

--- a/mxops/execution/steps/setup.py
+++ b/mxops/execution/steps/setup.py
@@ -47,6 +47,7 @@ class GenerateWalletsStep(Step):
         Create the wanted wallets at the designated location
 
         """
+        scenario_data = ScenarioData.get()
         save_folder = self.save_folder.get_evaluated_value()
         save_folder.mkdir(parents=True, exist_ok=True)
         wallets = self.wallets.get_evaluated_value()
@@ -73,6 +74,9 @@ class GenerateWalletsStep(Step):
                 raise errors.WalletAlreadyExist(wallet_path)
 
             pem_wallet.save(wallet_path)
+            scenario_data.set_value(
+                f"{wallet_name}.address", wallet_address.to_bech32()
+            )
             LOGGER.info(
                 f"Wallet n°{i + 1}/{n_wallets} generated with address "
                 f"{wallet_address.to_bech32()} at {wallet_path}"

--- a/mxops/execution/steps/smart_contract.py
+++ b/mxops/execution/steps/smart_contract.py
@@ -303,6 +303,7 @@ class ContractCallStep(TransactionStep):
             raise ValueError("No data to save")
 
         if self.results_save_keys is not None:
+            self.saved_results = {}
             results_save_keys = self.results_save_keys.get_evaluated_value()
             to_save = results_save_keys.parse_data_to_save(self.returned_data_parts)
             for save_key, value in to_save.items():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mxops"
-version = "3.0.0-dev29"
+version = "3.0.0-dev30"
 authors = [
   {name="Etienne Wallet"},
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.0-dev29
+current_version = 3.0.0-dev30
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<release>[^-0-9]+)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}{build}

--- a/tests/test_setup_steps.py
+++ b/tests/test_setup_steps.py
@@ -29,7 +29,7 @@ def test_generate_n_wallet_step():
 def test_generate_named_wallet_step():
     # Given
     step = GenerateWalletsStep(
-        "./tests/data/TEMP_UNIT_TEST/wallets/folder", ["alice", "bob"]
+        "./tests/data/TEMP_UNIT_TEST/wallets/folder", ["charles", "david"]
     )
 
     # When
@@ -38,7 +38,7 @@ def test_generate_named_wallet_step():
     # Then
     save_folder = Path("./tests/data/TEMP_UNIT_TEST/wallets/folder")
     files = os.listdir(save_folder)
-    assert set(files) == {"alice.pem", "bob.pem"}
+    assert set(files) == {"charles.pem", "david.pem"}
     for file in files:
         _ = Account.new_from_pem(save_folder / file)
 


### PR DESCRIPTION
Added:
- addresses of newly generated wallets are saved within the scenario to allow for immediate reuse