### PR TITLE
fix: generate the first epoch when starting the chain simulator

### DIFF
--- a/mxops/common/providers.py
+++ b/mxops/common/providers.py
@@ -35,6 +35,10 @@ class MyProxyNetworkProvider(ProxyNetworkProvider):
         url = f"simulator/generate-blocks/{n_blocks}"
         return self.do_post_generic(url, None)
 
+    def generate_blocks_until_epoch(self, epoch: int) -> GenericResponse:
+        url = f"simulator/generate-blocks-until-epoch-reached/{epoch}"
+        return self.do_post_generic(url, None)
+
     def set_state(self, states: list[dict]) -> GenericResponse:
         url = "simulator/set-state"
         return self.do_post_generic(url, states)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mxops"
-version = "3.0.0-dev38"
+version = "3.0.0-dev39"
 authors = [
   {name="Etienne Wallet"},
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.0-dev38
+current_version = 3.0.0-dev39
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<release>[^-0-9]+)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}{build}


### PR DESCRIPTION
Fixed:
- automatically generate the first epoch when starting the chain simulator to avoid sc deployment error