### PR TITLE
Breaking/rename print result to log result

### DIFF
--- a/docs/source/dev_documentation/changelog.md
+++ b/docs/source/dev_documentation/changelog.md
@@ -69,7 +69,7 @@
 - 🚨 BREAKING CHANGE 🚨 cli and smart-values have been moved into dedicated sub-packages
 - 🚨 BREAKING CHANGE 🚨 step argument `print_results` was changed to `log_results` and is set to True by default
 - 🚨 BREAKING CHANGE 🚨 renamed `wasm_hash` to `code_hash`
-
+- 🚨 BREAKING CHANGE 🚨 step argument `print_result` was changed to `log_result` and is set to True by default
 
 
 ## 2.2.0 - 2024-04-16

--- a/docs/source/user_documentation/steps.md
+++ b/docs/source/user_documentation/steps.md
@@ -748,7 +748,7 @@ arguments:  # optional
 keyword_arguments:  # optional
   key_1: value_1
   key_2: "$VALUE"  # using os env var
-print_result: True  # optional
+log_result: True  # optional
 result_save_key: "my_result"  # optional, key under which save the function result
 ```
 

--- a/mxops/execution/steps/msc.py
+++ b/mxops/execution/steps/msc.py
@@ -183,7 +183,7 @@ class PythonStep(Step):
     function: SmartStr
     arguments: SmartList = field(default_factory=lambda: SmartList([]))
     keyword_arguments: SmartDict = field(default_factory=lambda: SmartDict({}))
-    print_result: SmartBool = True
+    log_result: SmartBool = True
     result_save_key: SmartStr | None = None
 
     def _execute(self):
@@ -216,7 +216,7 @@ class PythonStep(Step):
             logger.info(
                 f"Saving function result at {result_save_key}: {json_dumps(result)}"
             )
-        elif self.print_result.get_evaluated_value():
+        elif self.log_result.get_evaluated_value():
             logger.info(f"Function result: {json_dumps(result)}")
 
 

--- a/tests/test_msc_steps.py
+++ b/tests/test_msc_steps.py
@@ -297,7 +297,7 @@ def test_python_step():
         module_path,
         function,
         ["my_test_contract", "my_test_key", "my_test_value"],
-        print_result=True,
+        log_result=True,
         result_save_key="result_1",
     )
 
@@ -309,7 +309,7 @@ def test_python_step():
             "value_key": "my_test_key",
             "value": 4582,
         },
-        print_result=True,
+        log_result=True,
         result_save_key="result_2",
     )
 


### PR DESCRIPTION
Modified:
- rename print_result to log_result, change missed during PR #128 