### PR TITLE
Fix chain-simulator explorer/lite-wallet container restart failures

### DIFF
--- a/docs/dictionary/custom_wordlist.txt
+++ b/docs/dictionary/custom_wordlist.txt
@@ -36,6 +36,7 @@ https
 monotypes
 Monotypes
 natively
+nginx
 os
 permissioned
 pipx

--- a/docs/source/dev_documentation/changelog.md
+++ b/docs/source/dev_documentation/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Chain simulator explorer and lite-wallet containers failing on restart due to non-idempotent nginx config in upstream images (added `--force-recreate` to `docker compose up`)
+
 ## 3.1.0 - 2026-02-11
 
 ### Added

--- a/mxops/utils/chain_simulator.py
+++ b/mxops/utils/chain_simulator.py
@@ -277,7 +277,15 @@ def start_chain_simulator(
 
     LOGGER.info("Starting the chain simulator")
     process = subprocess.Popen(  # nosec
-        ["docker", "compose", "-f", file_path.as_posix(), "up", "-d", "--force-recreate"],
+        [
+            "docker",
+            "compose",
+            "-f",
+            file_path.as_posix(),
+            "up",
+            "-d",
+            "--force-recreate",
+        ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         universal_newlines=True,

--- a/mxops/utils/chain_simulator.py
+++ b/mxops/utils/chain_simulator.py
@@ -277,7 +277,7 @@ def start_chain_simulator(
 
     LOGGER.info("Starting the chain simulator")
     process = subprocess.Popen(  # nosec
-        ["docker", "compose", "-f", file_path.as_posix(), "up", "-d"],
+        ["docker", "compose", "-f", file_path.as_posix(), "up", "-d", "--force-recreate"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         universal_newlines=True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mxops"
-version = "3.1.0"
+version = "3.1.1-dev0"
 authors = [
   {name="Etienne Wallet"},
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.1.0
+current_version = 3.1.1-dev0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<release>[^-0-9]+)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}{build}


### PR DESCRIPTION
## Summary

- Fix explorer and lite-wallet containers crashing with `duplicate location "/assets/"` nginx error when restarted without being fully removed first

## Changes

- Add `--force-recreate` flag to `docker compose up -d` in `start_chain_simulator()` to ensure containers are always recreated from a clean state
- The upstream MultiversX Docker images (`mx-explorer-dapp`, `mx-lite-wallet-dapp`) have non-idempotent entrypoint scripts that append duplicate nginx `location /assets/` blocks on each container start, causing nginx to reject the config on subsequent runs

## Testing

- Reproduced the issue by inspecting docker logs showing `duplicate location "/assets/"` errors
- Verified fix by removing stale containers and recreating them fresh — nginx starts successfully with clean worker processes

🤖 Generated with [Claude Code](https://claude.com/claude-code)