### PR TITLE
feat: add ChainSimulatorSetTokenBalanceStep for arbitrary ESDT balance creation

### DIFF
--- a/docs/dictionary/custom_wordlist.txt
+++ b/docs/dictionary/custom_wordlist.txt
@@ -45,6 +45,7 @@ png
 pre
 PyPI
 pytest
+queryable
 Readthedocs
 yaml
 svg

--- a/docs/source/dev_documentation/changelog.md
+++ b/docs/source/dev_documentation/changelog.md
@@ -6,6 +6,7 @@
 
 - `AccountBatchCloneStep` for optimized bulk account cloning: collects all data first, then pushes with single ESDT module reconciliation, single Elasticsearch bulk insert, and smart payload-sized batched `set_state` calls
 - `ChainSimulatorSetStateStep` to set specific hex-encoded storage key-value pairs for an address on the chain simulator
+- `ChainSimulatorSetTokenBalanceStep` to set arbitrary fungible ESDT balances on accounts in the chain simulator, auto-cloning token registrations from a source network when missing
 - Explicit test for variadic counted values
 - Dynamic batch size recovery: after a timeout reduces the batch size, subsequent successful requests with smaller payloads automatically double the batch size back toward the original (for both storage fetch and push operations)
 - Tests verifying batch size resets between accounts

--- a/docs/source/user_documentation/steps.md
+++ b/docs/source/user_documentation/steps.md
@@ -690,6 +690,41 @@ keys:
   "6d795f6f746865725f6b6579": "01"
 ```
 
+(chain_simulator_set_token_balance_target)=
+### Chain Simulator Set Token Balance Step
+
+Exclusive to the chain simulator.
+This step allows you to give arbitrary amounts of fungible ESDT tokens to one or more accounts, without going through any on-chain transaction. It is the inverse of [Account Clone](#account_clone_target): instead of cloning real balances from a source network, you specify exactly which token, which receiver, and how many units they should hold.
+
+If a referenced token is not yet registered on the chain simulator, the step automatically clones its registration from `source_network` (default: `mainnet`) — using the same plumbing as `AccountClone`. As a result, the tokens behave as if they had been natively issued on the chain simulator: they are visible in the explorer, queryable through the proxy, and usable in subsequent transactions.
+
+```yaml
+type: ChainSimulatorSetTokenBalance
+source_network: mainnet  # optional, default to mainnet
+caching_period: "10 days"  # optional, default to 10 days
+balances:
+  - receiver: "%alice.address"
+    token_identifier: WEGLD-bd4d79
+    amount: 5000000000000000000  # 5 WEGLD
+  - receiver: "%alice.address"
+    token_identifier: USDC-c76f1f
+    amount: 1000000  # 1 USDC (6 decimals)
+  - receiver: bob
+    token_identifier: USDC-c76f1f
+    amount: 250000000
+```
+
+- `source_network` controls which network the step queries when a token is not yet registered on the simulator's ESDT module. Tokens already registered are not re-fetched.
+- `caching_period` controls how long previously-fetched source-network data (the ESDT module entry and its companion Elasticsearch document) is reused before being re-fetched. It has no effect once a token is registered on the simulator — re-registration only happens if the local ESDT module entry is missing.
+
+```{warning}
+This step only supports **fungible** tokens (no nonce). NFT, SFT and Meta-ESDT minting from thin air is not yet supported — use [Account Clone](#account_clone_target) with a real holder as the source for those.
+```
+
+```{note}
+"From thin air" balances are written directly to the receiver's storage via the chain-simulator address-level set-state endpoint, which only modifies the storage keys it is given. Other account fields (nonce, balance, code, other storage) are left untouched. The registered supply on the ESDT module entry is **not** incremented either, which is fine for the vast majority of test scenarios but may matter if your contracts read the on-module supply.
+```
+
 (account_clone_target)=
 ### Account Clone Step
 

--- a/integration_tests/token_thin_air/mxops_scenes/01_mint.yaml
+++ b/integration_tests/token_thin_air/mxops_scenes/01_mint.yaml
@@ -1,0 +1,65 @@
+allowed_networks:
+  - chain-simulator
+
+allowed_scenario:
+  - "integration_test_token_thin_air.*"
+
+steps:
+  # Mint two real mainnet fungible tokens to two different receivers in a
+  # single step. Tokens that are not yet registered on the chain simulator
+  # are auto-cloned from mainnet by the step itself.
+  - type: ChainSimulatorSetTokenBalance
+    source_network: mainnet
+    balances:
+      - receiver: "%paul.address"
+        token_identifier: WEGLD-bd4d79
+        amount: 450000000000000000000  # 450 WEGLD
+      - receiver: "%paul.address"
+        token_identifier: USDC-c76f1f
+        amount: 1000000  # 1 USDC (6 decimals)
+      - receiver: "%marie.address"
+        token_identifier: USDC-c76f1f
+        amount: 250000000  # 250 USDC
+
+  # Verify the balances actually landed in the simulator's ESDT storage
+  # by going through the standard proxy lookup endpoint.
+  - type: Python
+    module_path: ./integration_tests/token_thin_air/scripts/checks.py
+    function: assert_account_token_balance
+    arguments:
+      - paul
+      - WEGLD-bd4d79
+      - 450000000000000000000
+
+  - type: Python
+    module_path: ./integration_tests/token_thin_air/scripts/checks.py
+    function: assert_account_token_balance
+    arguments:
+      - paul
+      - USDC-c76f1f
+      - 1000000
+
+  - type: Python
+    module_path: ./integration_tests/token_thin_air/scripts/checks.py
+    function: assert_account_token_balance
+    arguments:
+      - marie
+      - USDC-c76f1f
+      - 250000000
+
+  # Re-running the step on already-registered tokens must be a no-op for
+  # the registration phase and only update the balances. Bumps Paul's USDC
+  # to confirm overwriting an existing thin-air balance also works.
+  - type: ChainSimulatorSetTokenBalance
+    balances:
+      - receiver: "%paul.address"
+        token_identifier: USDC-c76f1f
+        amount: 9999999  # 9.999999 USDC
+
+  - type: Python
+    module_path: ./integration_tests/token_thin_air/scripts/checks.py
+    function: assert_account_token_balance
+    arguments:
+      - paul
+      - USDC-c76f1f
+      - 9999999

--- a/integration_tests/token_thin_air/scripts/checks.py
+++ b/integration_tests/token_thin_air/scripts/checks.py
@@ -1,0 +1,37 @@
+"""
+Checks for the token_thin_air integration test.
+Verifies that ESDT balances set "from thin air" via
+ChainSimulatorSetTokenBalanceStep are observable through the standard
+proxy ESDT lookup endpoints.
+"""
+
+from multiversx_sdk import Address, Token
+
+from mxops.common.providers import MyProxyNetworkProvider
+from mxops.data.execution_data import ScenarioData
+
+
+def assert_account_token_balance(
+    account_id: str, token_identifier: str, expected_amount: int
+):
+    """
+    Query the chain simulator for the ESDT balance of an account and assert
+    it matches the expected amount.
+
+    :param account_id: MxOps account id (must resolve to a bech32 address)
+    :param token_identifier: ESDT token identifier (e.g. "WEGLD-bd4d79")
+    :param expected_amount: balance the account should hold (integer units)
+    """
+    scenario_data = ScenarioData.get()
+    bech32 = scenario_data.get_account_value(account_id, "bech32")
+    address = Address.new_from_bech32(bech32)
+    expected_amount = int(expected_amount)
+
+    proxy = MyProxyNetworkProvider()
+    on_network = proxy.get_token_of_account(address, Token(token_identifier))
+    actual = int(on_network.amount)
+    if actual != expected_amount:
+        raise AssertionError(
+            f"Balance mismatch for {account_id} / {token_identifier}: "
+            f"expected {expected_amount}, got {actual}"
+        )

--- a/integration_tests/token_thin_air/scripts/run_test.sh
+++ b/integration_tests/token_thin_air/scripts/run_test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+if ! [[ " ${1} " =~ " chain-simulator " ]]; then
+    echo "Token thin-air tests not available on ${1}"
+    exit 0
+fi
+
+uv run mxops \
+    execute \
+    -n $1 \
+    -s integration_test_token_thin_air \
+    -c \
+    integration_tests/setup_scenes/01_accounts.yaml \
+    integration_tests/token_thin_air/mxops_scenes

--- a/mxops/execution/steps/__init__.py
+++ b/mxops/execution/steps/__init__.py
@@ -19,6 +19,7 @@ from mxops.execution.steps.setup import (
     AccountCloneStep,
     ChainSimulatorFaucetStep,
     ChainSimulatorSetStateStep,
+    ChainSimulatorSetTokenBalanceStep,
     GenerateWalletsStep,
     R3D4FaucetStep,
 )
@@ -49,6 +50,7 @@ __all__ = [
     "AssertStep",
     "ChainSimulatorFaucetStep",
     "ChainSimulatorSetStateStep",
+    "ChainSimulatorSetTokenBalanceStep",
     "ContractCallStep",
     "ContractDeployStep",
     "ContractQueryStep",

--- a/mxops/execution/steps/setup.py
+++ b/mxops/execution/steps/setup.py
@@ -6,10 +6,11 @@ This module contains Steps used to setup environment, chain or workflow
 
 from configparser import NoOptionError
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 import json
 import os
+import re
 import time
 from typing import ClassVar
 
@@ -480,7 +481,7 @@ def _get_esdt_module_clone_data(
     esdt_identifiers: set[str],
     source_network: NetworkEnum,
     caching_period: datetime,
-) -> dict:
+) -> tuple[dict, set[str]]:
     """
     Using a set of identifiers, determine for each ESDT if it is already known
     to the current network, otherwise fetch the data from the source network.
@@ -488,7 +489,11 @@ def _get_esdt_module_clone_data(
     :param esdt_identifiers: ESDT identifiers to check
     :param source_network: network to fetch missing entries from
     :param caching_period: caching threshold for data freshness
-    :return: data to set for the ESDT module
+    :return: tuple of (ESDT module account data to push, set of identifiers
+        that had to be cloned from the source network). The second element
+        is empty when every requested identifier was already present locally,
+        which lets callers skip downstream work (Elasticsearch insertion,
+        set_state pushes) on the no-op path.
     """
     proxy = MyProxyNetworkProvider()
     esdt_module_address = Address.new_from_bech32(ESDT_MODULE_BECH32)
@@ -503,7 +508,7 @@ def _get_esdt_module_clone_data(
         esdt_identifiers, current_hex_keys
     )
     if not missing_identifiers:
-        return raw_account_data
+        return raw_account_data, set()
 
     logger = ScenarioData.get_scenario_logger(LogGroupEnum.EXEC)
     logger.debug(
@@ -518,7 +523,7 @@ def _get_esdt_module_clone_data(
         caching_period,
     )
 
-    return raw_account_data
+    return raw_account_data, set(missing_identifiers)
 
 
 def _fetch_with_backoff(
@@ -741,11 +746,14 @@ class AccountCloneStep(Step):
             esdt_seen = set()
 
         if len(esdt_seen) > 0:
-            esdt_module_state = _get_esdt_module_clone_data(
+            esdt_module_state, newly_cloned = _get_esdt_module_clone_data(
                 esdt_seen, source_network, caching_period
             )
-            proxy.set_state([esdt_module_state])
-            _insert_tokens_in_elasticsearch(esdt_seen, source_network, caching_period)
+            if newly_cloned:
+                proxy.set_state([esdt_module_state])
+                _insert_tokens_in_elasticsearch(
+                    newly_cloned, source_network, caching_period
+                )
 
         set_state_with_batching(
             proxy,
@@ -861,36 +869,38 @@ class AccountBatchCloneStep(Step):
         # Phase 2: Single ESDT module reconciliation
         phase2_start = time.time()
         proxy = MyProxyNetworkProvider()
+        newly_cloned: set[str] = set()
         if all_esdt_identifiers:
             logger.info(
                 f"Phase 2/4: Reconciling {len(all_esdt_identifiers)} "
                 f"unique ESDT identifiers with chain simulator"
             )
-            esdt_module_state = _get_esdt_module_clone_data(
+            esdt_module_state, newly_cloned = _get_esdt_module_clone_data(
                 all_esdt_identifiers, source_network, caching_period
             )
             # Insert ESDT module state as first element so it is included
             # in the overwrite batch and not wiped by a subsequent
             # set_state_overwrite call
-            if esdt_module_state.get("pairs"):
+            if newly_cloned:
                 all_account_states.insert(0, esdt_module_state)
         else:
             logger.info("Phase 2/4: No ESDT identifiers to reconcile, skipping")
         phase2_elapsed = time.time() - phase2_start
         logger.info(f"Phase 2/4 completed in {phase2_elapsed:.1f}s")
 
-        # Phase 3: Single Elasticsearch bulk insert
+        # Phase 3: Bulk-insert only the newly-cloned tokens into Elasticsearch.
+        # Identifiers that were already known to the simulator have nothing
+        # new to push, so we don't re-fetch them from the source network.
         phase3_start = time.time()
-        if all_esdt_identifiers:
+        if newly_cloned:
             logger.info(
-                f"Phase 3/4: Inserting {len(all_esdt_identifiers)} "
-                "tokens into Elasticsearch"
+                f"Phase 3/4: Inserting {len(newly_cloned)} tokens into Elasticsearch"
             )
             _insert_tokens_in_elasticsearch(
-                all_esdt_identifiers, source_network, caching_period
+                newly_cloned, source_network, caching_period
             )
         else:
-            logger.info("Phase 3/4: No tokens to insert, skipping")
+            logger.info("Phase 3/4: No new tokens to insert, skipping")
         phase3_elapsed = time.time() - phase3_start
         logger.info(f"Phase 3/4 completed in {phase3_elapsed:.1f}s")
 
@@ -911,3 +921,230 @@ class AccountBatchCloneStep(Step):
             f"Phase 4/4 completed in {phase4_elapsed:.1f}s. "
             f"Total batch clone: {total_elapsed:.1f}s"
         )
+
+
+# Fungible identifier shape: TICKER (3-10 alphanum, uppercase letters allowed)
+# followed by a dash and 6 lowercase hex chars. Anything beyond that is rejected
+# by ChainSimulatorSetTokenBalanceStep (NFT/SFT/Meta-ESDT not supported in v1).
+_FUNGIBLE_IDENTIFIER_RE = re.compile(r"^[A-Z0-9]{3,10}-[0-9a-f]{6}$")
+
+
+def _encode_fungible_esdt_value(amount: int) -> str:
+    """
+    Build the hex-encoded ESDigitalToken protobuf for a fungible balance.
+
+    The chain simulator stores ESDT balances as protobuf-encoded ESDigitalToken
+    messages. For a fungible balance only field 2 (``Value``) is set. mx-chain
+    encodes ``Value`` as a positive sign byte ``0x00`` followed by the big-endian
+    bytes of the amount (Go's ``big.Int.Bytes()`` form). Without the leading
+    sign byte the simulator rejects the value with an "invalid sign byte"
+    error when ``address/.../esdt/...`` is queried; cross-checked against
+    real mainnet entries (e.g. WEGLD-bd4d79 holders).
+
+    :param amount: positive amount to encode
+    :return: hex-encoded protobuf ESDigitalToken
+    """
+    if amount <= 0:
+        raise errors.InvalidSceneDefinition(
+            "ChainSimulatorSetTokenBalance amount must be a strictly positive "
+            f"integer, got {amount}"
+        )
+    abs_bytes = amount.to_bytes((amount.bit_length() + 7) // 8, "big")
+    value_bytes = b"\x00" + abs_bytes
+    if len(value_bytes) >= 0x80:
+        # Defensive: a 16-byte amount already covers 2^128 - 1, so any token
+        # balance fits well under 128 bytes. Reject anything larger so we
+        # don't have to deal with multi-byte protobuf varint lengths. The
+        # 1-byte sign byte plus a 127-byte amount is the strict ceiling, so
+        # the maximum accepted amount is (2 ** (127 * 8)) - 1.
+        raise errors.InvalidSceneDefinition(
+            "ChainSimulatorSetTokenBalance amount is too large to encode "
+            "(must fit in 127 bytes / under 2 ** 1016)"
+        )
+    return "12" + len(value_bytes).to_bytes(1, "big").hex() + value_bytes.hex()
+
+
+def _build_fungible_esdt_storage_key(identifier: str) -> str:
+    """
+    Build the hex-encoded ESDT balance storage key for a fungible token.
+
+    Format: ELRONDesdt (hex prefix) || utf8(identifier) (hex). No nonce suffix
+    is appended for fungible tokens.
+
+    :param identifier: fungible token identifier ("TICKER-RANDOM")
+    :return: hex-encoded storage key
+    """
+    if not _FUNGIBLE_IDENTIFIER_RE.match(identifier):
+        raise errors.InvalidSceneDefinition(
+            f"ChainSimulatorSetTokenBalance: '{identifier}' is not a valid "
+            "fungible ESDT identifier. Expected 'TICKER-RANDOM' with TICKER "
+            "being 3-10 uppercase alphanumeric characters and RANDOM being "
+            "6 lowercase hex characters. NFT/SFT/Meta-ESDT (nonce > 0) are "
+            "not supported in this step."
+        )
+    return ESDT_BALANCE_STORAGE_HEX_PREFIX + identifier.encode("utf-8").hex()
+
+
+@dataclass
+class TokenBalanceSpec:
+    """
+    A single (receiver, fungible token, amount) mint specification used by
+    :class:`ChainSimulatorSetTokenBalanceStep`.
+    """
+
+    receiver: SmartAddress
+    token_identifier: SmartStr
+    amount: SmartInt
+
+    def __post_init__(self):
+        if not isinstance(self.receiver, SmartAddress):
+            self.receiver = SmartAddress(self.receiver)
+        if not isinstance(self.token_identifier, SmartStr):
+            self.token_identifier = SmartStr(self.token_identifier)
+        if not isinstance(self.amount, SmartInt):
+            self.amount = SmartInt(self.amount)
+
+    def evaluate_smart_values(self):
+        """Evaluate the smart values held by the spec."""
+        self.receiver.evaluate()
+        self.token_identifier.evaluate()
+        self.amount.evaluate()
+
+    @classmethod
+    def from_raw(cls, raw: "TokenBalanceSpec | dict") -> "TokenBalanceSpec":
+        """Build a TokenBalanceSpec from a YAML-loaded dict or pass-through."""
+        if isinstance(raw, cls):
+            return raw
+        if not isinstance(raw, dict):
+            raise errors.InvalidSceneDefinition(
+                "ChainSimulatorSetTokenBalance balances entries must be "
+                f"mappings with 'receiver', 'token_identifier' and 'amount' "
+                f"keys, got {type(raw).__name__}"
+            )
+        try:
+            return cls(
+                receiver=raw["receiver"],
+                token_identifier=raw["token_identifier"],
+                amount=raw["amount"],
+            )
+        except KeyError as err:
+            raise errors.InvalidSceneDefinition(
+                "ChainSimulatorSetTokenBalance balances entry is missing the "
+                f"required key {err.args[0]!r}"
+            ) from err
+
+
+@dataclass
+class ChainSimulatorSetTokenBalanceStep(Step):
+    """
+    Set arbitrary fungible ESDT balances on accounts in the chain simulator,
+    bypassing on-chain transactions. If a referenced token is not yet
+    registered on the simulator, its registration is automatically cloned
+    from the configured ``source_network`` (default: mainnet).
+    """
+
+    balances: list[TokenBalanceSpec] = field(default_factory=list)
+    source_network: SmartStr = "mainnet"
+    caching_period: SmartDatetime = "10 days"
+    ALLOWED_NETWORKS: ClassVar[tuple[NetworkEnum, ...]] = (NetworkEnum.CHAIN_SIMULATOR,)
+
+    def _initialize(self):
+        """Coerce raw dict entries from YAML into TokenBalanceSpec instances.
+
+        Pure conversion only — input validation (empty list, network gate)
+        runs in ``_execute`` so the network check happens before any work.
+        """
+        if all(isinstance(b, TokenBalanceSpec) for b in self.balances):
+            return
+        self.balances = [TokenBalanceSpec.from_raw(b) for b in self.balances]
+
+    def evaluate_smart_values(self):
+        super().evaluate_smart_values()
+        for spec in self.balances:
+            spec.evaluate_smart_values()
+
+    def _execute(self):
+        # Network gate first: refuse to do any work — no scenario lookups,
+        # no source-network fetches, no ESDT-module reconciliation — when
+        # the active network is not the chain simulator.
+        scenario_data = ScenarioData.get()
+        if scenario_data.network not in self.ALLOWED_NETWORKS:
+            raise errors.WrongNetworkForStep(
+                scenario_data.network, self.ALLOWED_NETWORKS
+            )
+        if not self.balances:
+            raise errors.InvalidSceneDefinition(
+                "ChainSimulatorSetTokenBalance requires at least one entry "
+                "in 'balances'"
+            )
+
+        logger = ScenarioData.get_scenario_logger(LogGroupEnum.EXEC)
+        source_network = parse_network_enum(self.source_network.get_evaluated_value())
+        caching_period = self.caching_period.get_evaluated_value()
+
+        # Phase 1: validate every spec and pre-compute keys/values.
+        # Group keys by receiver bech32 so each address gets a single
+        # set_address_state call (preserves any existing storage).
+        per_receiver_pairs: dict[str, dict[str, str]] = {}
+        unique_identifiers: set[str] = set()
+        for spec in self.balances:
+            identifier = spec.token_identifier.get_evaluated_value()
+            amount = spec.amount.get_evaluated_value()
+            bech32 = spec.receiver.get_evaluated_value().to_bech32()
+
+            key = _build_fungible_esdt_storage_key(identifier)
+            value = _encode_fungible_esdt_value(amount)
+
+            receiver_pairs = per_receiver_pairs.setdefault(bech32, {})
+            if key in receiver_pairs:
+                raise errors.InvalidSceneDefinition(
+                    f"ChainSimulatorSetTokenBalance: token {identifier} is "
+                    f"specified more than once for receiver {bech32}. Combine "
+                    "the entries into a single balance spec."
+                )
+            receiver_pairs[key] = value
+            unique_identifiers.add(identifier)
+
+        logger.info(
+            f"Setting {sum(len(p) for p in per_receiver_pairs.values())} "
+            f"ESDT balances across {len(per_receiver_pairs)} receiver(s) "
+            f"on chain simulator (source for missing tokens: "
+            f"{source_network.value})"
+        )
+
+        # Phase 2: ensure every referenced token is registered on the
+        # simulator's ESDT module account. Reuses the same helpers as
+        # AccountCloneStep so missing tokens are fetched from the source
+        # network exactly once. Already-present tokens are reported via the
+        # empty newly_cloned set, which lets us skip both the set_state and
+        # the Elasticsearch insert on the no-op path.
+        proxy = MyProxyNetworkProvider()
+        esdt_module_state, newly_cloned = _get_esdt_module_clone_data(
+            unique_identifiers, source_network, caching_period
+        )
+        if newly_cloned:
+            logger.info(
+                f"Cloning {len(newly_cloned)} missing ESDT "
+                f"registration(s) from {source_network.value}"
+            )
+            proxy.set_state([esdt_module_state])
+            # Phase 3: insert token metadata into the local Elasticsearch
+            # so the simulator's explorer/API can resolve the new tokens.
+            # Best-effort: the helper handles missing ES gracefully.
+            _insert_tokens_in_elasticsearch(
+                newly_cloned, source_network, caching_period
+            )
+
+        # Phase 4: write each receiver's balance entries via set_address_state.
+        # This is the surgical primitive — it adds the given storage keys
+        # without touching any other field on the account (nonce, balance,
+        # code, other storage). set_state with a partial payload would risk
+        # zeroing fields when the receiver is a contract address.
+        for bech32, pairs in per_receiver_pairs.items():
+            logger.debug(f"Pushing {len(pairs)} ESDT balance key(s) to {bech32}")
+            proxy.set_address_state(bech32, pairs)
+
+        # Phase 5: generate a block so the new state is committed and visible
+        # via the standard proxy endpoints (e.g. address/.../esdt/...). Without
+        # this, get_token_of_account can keep returning the pre-write balance.
+        proxy.generate_blocks(1)

--- a/mxops/smart_values/__init__.py
+++ b/mxops/smart_values/__init__.py
@@ -20,6 +20,7 @@ from mxops.smart_values.mx_sdk import (
 )
 from mxops.smart_values.native import (
     SmartBytes,
+    SmartDatetime,
     SmartInt,
     SmartFloat,
     SmartBool,
@@ -35,6 +36,7 @@ __all__ = [
     "SmartBech32",
     "SmartBool",
     "SmartBytes",
+    "SmartDatetime",
     "SmartDict",
     "SmartFloat",
     "SmartInt",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mxops"
-version = "3.2.0-dev1"
+version = "3.2.0-dev2"
 authors = [
   {name="Etienne Wallet"},
 ]

--- a/scripts/launch_integration_tests.sh
+++ b/scripts/launch_integration_tests.sh
@@ -9,4 +9,5 @@ echo "Starting integration tests scenes"
 ./integration_tests/token_management/scripts/run_test.sh $1
 ./integration_tests/data_store/scripts/run_test.sh $1
 ./integration_tests/wrapper_clone/scripts/run_test.sh $1
+./integration_tests/token_thin_air/scripts/run_test.sh $1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.2.0-dev1
+current_version = 3.2.0-dev2
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<release>[^-0-9]+)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}{build}

--- a/tests/test_chain_simulator_set_token_balance.py
+++ b/tests/test_chain_simulator_set_token_balance.py
@@ -1,0 +1,317 @@
+"""
+Unit tests for ChainSimulatorSetTokenBalanceStep and its protobuf/key helpers.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from mxops import errors
+from mxops.enums import NetworkEnum
+from mxops.execution.steps import ChainSimulatorSetTokenBalanceStep
+from mxops.execution.steps.setup import (
+    _build_fungible_esdt_storage_key,
+    _encode_fungible_esdt_value,
+)
+
+
+MOCK_BECH32_A = "erd1qqqqqqqqqqqqqpgqdmq43snzxutandvqefxgj89r6fh528v9dwnswvgq9t"
+MOCK_BECH32_B = "erd1qqqqqqqqqqqqqpgqxt0y7s830gh5r38ypsslt9hrd2zxn98rv5ys0jd2mg"
+
+USDC = "USDC-c76f1f"
+WEGLD = "WEGLD-bd4d79"
+
+
+@pytest.fixture
+def chain_simulator_scenario(scenario_data, chain_simulator_network):
+    """Set both Config and ScenarioData to chain simulator network."""
+    original = scenario_data.network
+    scenario_data.network = NetworkEnum.CHAIN_SIMULATOR
+    yield scenario_data
+    scenario_data.network = original
+
+
+# ---- _encode_fungible_esdt_value ----------------------------------------
+
+
+@pytest.mark.parametrize(
+    "amount, expected",
+    [
+        # protobuf field 2 (tag 0x12) || varint length || 0x00 sign byte || amount
+        (1, "12020001"),
+        (255, "120200ff"),
+        (256, "1203000100"),
+        (100_000, "120400" + "0186a0"),
+        # 10**18 = 0x0DE0B6B3A7640000 (8 bytes) -- typical EGLD-decimals amount.
+        # 1 sign byte + 8 amount bytes = 9 bytes total -> length 0x09.
+        (10**18, "120900" + "0de0b6b3a7640000"),
+        # Cross-check against a real mainnet WEGLD-bd4d79 holder
+        # (xExchange WEGLD/USDC pool, balance 194479365022391160170385).
+        (194_479_365_022_391_160_170_385, "120b00292ebf5c5c0731866791"),
+    ],
+)
+def test_encode_fungible_esdt_value_known_amounts(amount, expected):
+    assert _encode_fungible_esdt_value(amount) == expected
+
+
+def test_encode_fungible_esdt_value_rejects_zero():
+    with pytest.raises(errors.InvalidSceneDefinition, match="strictly positive"):
+        _encode_fungible_esdt_value(0)
+
+
+def test_encode_fungible_esdt_value_rejects_negative():
+    with pytest.raises(errors.InvalidSceneDefinition, match="strictly positive"):
+        _encode_fungible_esdt_value(-1)
+
+
+def test_encode_fungible_esdt_value_rejects_overlarge():
+    with pytest.raises(errors.InvalidSceneDefinition, match="too large"):
+        _encode_fungible_esdt_value(1 << 1024)
+
+
+# ---- _build_fungible_esdt_storage_key -----------------------------------
+
+
+def test_build_storage_key_usdc():
+    # 454c524f4e4465736474 == ELRONDesdt
+    # 55534443 == "USDC", 2d == "-", 633736663166 == "c76f1f"
+    expected = "454c524f4e4465736474" + "55534443" + "2d" + "633736663166"
+    assert _build_fungible_esdt_storage_key(USDC) == expected
+
+
+def test_build_storage_key_wegld():
+    expected = "454c524f4e4465736474" + "5745474c44" + "2d" + "626434643739"
+    assert _build_fungible_esdt_storage_key(WEGLD) == expected
+
+
+@pytest.mark.parametrize(
+    "bad_identifier",
+    [
+        "usdc-c76f1f",  # lowercase ticker
+        "USDCC76F1F",  # missing dash
+        "U-c76f1f",  # ticker too short
+        "TOOLONGNAME12-c76f1f",  # ticker too long (12 chars > 10)
+        "USDC-C76F1F",  # uppercase random
+        "USDC-c76f1g",  # non-hex char
+        "USDC-c76f1f-01",  # NFT-style nonce suffix
+        "",
+    ],
+)
+def test_build_storage_key_rejects_bad_identifier(bad_identifier):
+    with pytest.raises(errors.InvalidSceneDefinition, match="not a valid"):
+        _build_fungible_esdt_storage_key(bad_identifier)
+
+
+# ---- ChainSimulatorSetTokenBalanceStep.execute --------------------------
+
+
+def _make_step(balances, source_network="mainnet"):
+    return ChainSimulatorSetTokenBalanceStep(
+        balances=balances, source_network=source_network
+    )
+
+
+def _patched_run(step):
+    """Execute the step under all mocks the new step needs.
+
+    Returns the (module, ES, set_state, set_address_state, generate_blocks)
+    mocks for assertion. Default _get_esdt_module_clone_data return value
+    means "no token needed cloning" so the cheap path is exercised.
+    """
+    with patch(
+        "mxops.execution.steps.setup._get_esdt_module_clone_data",
+        return_value=({"address": "esdt-mod", "pairs": {}}, set()),
+    ) as mock_module, patch(
+        "mxops.execution.steps.setup._insert_tokens_in_elasticsearch"
+    ) as mock_es, patch(
+        "mxops.execution.steps.setup.MyProxyNetworkProvider.set_state"
+    ) as mock_state, patch(
+        "mxops.execution.steps.setup.MyProxyNetworkProvider.set_address_state"
+    ) as mock_addr, patch(
+        "mxops.execution.steps.setup.MyProxyNetworkProvider.generate_blocks"
+    ) as mock_blocks:
+        step.execute()
+    return mock_module, mock_es, mock_state, mock_addr, mock_blocks
+
+
+def test_step_wrong_network(scenario_data):
+    """Network is LOCAL by default, step should reject it."""
+    step = _make_step(
+        [{"receiver": MOCK_BECH32_A, "token_identifier": USDC, "amount": 100}]
+    )
+    with pytest.raises(errors.WrongNetworkForStep):
+        step.execute()
+
+
+def test_step_wrong_network_skips_all_work(scenario_data):
+    """The wrong-network gate must run before any source-network or
+    chain-simulator work, regardless of how the balances list looks."""
+    step = _make_step(
+        [{"receiver": MOCK_BECH32_A, "token_identifier": USDC, "amount": 100}]
+    )
+    with patch(
+        "mxops.execution.steps.setup._get_esdt_module_clone_data"
+    ) as mock_module, patch(
+        "mxops.execution.steps.setup._insert_tokens_in_elasticsearch"
+    ) as mock_es, patch(
+        "mxops.execution.steps.setup.MyProxyNetworkProvider.set_address_state"
+    ) as mock_addr, patch(
+        "mxops.execution.steps.setup.MyProxyNetworkProvider.set_state"
+    ) as mock_state, patch(
+        "mxops.execution.steps.setup.MyProxyNetworkProvider.generate_blocks"
+    ) as mock_blocks:
+        with pytest.raises(errors.WrongNetworkForStep):
+            step.execute()
+    mock_module.assert_not_called()
+    mock_es.assert_not_called()
+    mock_addr.assert_not_called()
+    mock_state.assert_not_called()
+    mock_blocks.assert_not_called()
+
+
+def test_step_empty_balances_rejected(chain_simulator_scenario):
+    step = _make_step([])
+    with pytest.raises(errors.InvalidSceneDefinition, match="at least one"):
+        step.execute()
+
+
+def test_step_missing_balance_key_rejected(chain_simulator_scenario):
+    step = _make_step([{"receiver": MOCK_BECH32_A, "token_identifier": USDC}])
+    with pytest.raises(errors.InvalidSceneDefinition, match="missing the required"):
+        step.execute()
+
+
+def test_step_duplicate_token_per_receiver_rejected(chain_simulator_scenario):
+    step = _make_step(
+        [
+            {"receiver": MOCK_BECH32_A, "token_identifier": USDC, "amount": 100},
+            {"receiver": MOCK_BECH32_A, "token_identifier": USDC, "amount": 200},
+        ]
+    )
+    with pytest.raises(
+        errors.InvalidSceneDefinition, match="specified more than once"
+    ):
+        _patched_run(step)
+
+
+def test_step_invalid_identifier_rejected(chain_simulator_scenario):
+    step = _make_step(
+        [
+            {
+                "receiver": MOCK_BECH32_A,
+                "token_identifier": "usdc-c76f1f",
+                "amount": 100,
+            }
+        ]
+    )
+    with pytest.raises(errors.InvalidSceneDefinition, match="not a valid"):
+        _patched_run(step)
+
+
+def test_step_success_groups_by_receiver(chain_simulator_scenario):
+    """Two tokens to A and one to B should produce one set_address_state call
+    per unique receiver (with all that receiver's keys merged into a single
+    payload), a single ESDT-module reconciliation pass, and exactly one
+    generate_blocks(1) call. When _get_esdt_module_clone_data reports nothing
+    was newly cloned, ES insertion and module set_state must be skipped."""
+    step = _make_step(
+        [
+            {"receiver": MOCK_BECH32_A, "token_identifier": USDC, "amount": 100},
+            {"receiver": MOCK_BECH32_A, "token_identifier": WEGLD, "amount": 200},
+            {"receiver": MOCK_BECH32_B, "token_identifier": USDC, "amount": 300},
+        ]
+    )
+
+    mock_module, mock_es, mock_state, mock_addr, mock_blocks = _patched_run(step)
+
+    # ESDT module reconciliation called once with the deduped identifier set.
+    assert mock_module.call_count == 1
+    called_ids, _, _ = mock_module.call_args.args
+    assert called_ids == {USDC, WEGLD}
+
+    # Nothing was newly cloned -> no ES insertion, no module set_state.
+    mock_es.assert_not_called()
+    mock_state.assert_not_called()
+
+    # set_address_state called once per unique receiver.
+    assert mock_addr.call_count == 2
+    calls_by_addr = {c.args[0]: c.args[1] for c in mock_addr.call_args_list}
+    assert set(calls_by_addr.keys()) == {MOCK_BECH32_A, MOCK_BECH32_B}
+
+    # Receiver A has both keys.
+    a_pairs = calls_by_addr[MOCK_BECH32_A]
+    assert len(a_pairs) == 2
+    usdc_key = _build_fungible_esdt_storage_key(USDC)
+    wegld_key = _build_fungible_esdt_storage_key(WEGLD)
+    assert a_pairs[usdc_key] == _encode_fungible_esdt_value(100)
+    assert a_pairs[wegld_key] == _encode_fungible_esdt_value(200)
+
+    # Receiver B has only the USDC key with its own amount.
+    b_pairs = calls_by_addr[MOCK_BECH32_B]
+    assert b_pairs == {usdc_key: _encode_fungible_esdt_value(300)}
+
+    # The state must be committed via generate_blocks so proxy reads see it.
+    mock_blocks.assert_called_once_with(1)
+
+
+def test_step_pushes_esdt_module_only_for_newly_cloned(chain_simulator_scenario):
+    """If _get_esdt_module_clone_data signals that some tokens were cloned
+    (newly_cloned non-empty), the step must push the ESDT-module state via
+    set_state and call ES insertion only with the newly-cloned set, not
+    with already-known identifiers."""
+    step = _make_step(
+        [
+            {"receiver": MOCK_BECH32_A, "token_identifier": USDC, "amount": 100},
+            {"receiver": MOCK_BECH32_A, "token_identifier": WEGLD, "amount": 200},
+        ]
+    )
+
+    fake_module_state = {
+        "address": "esdt-mod-bech32",
+        "pairs": {"identifier-hex": "registration-bytes"},
+    }
+    with patch(
+        "mxops.execution.steps.setup._get_esdt_module_clone_data",
+        return_value=(fake_module_state, {USDC}),
+    ), patch(
+        "mxops.execution.steps.setup._insert_tokens_in_elasticsearch"
+    ) as mock_es, patch(
+        "mxops.execution.steps.setup.MyProxyNetworkProvider.set_state"
+    ) as mock_state, patch(
+        "mxops.execution.steps.setup.MyProxyNetworkProvider.set_address_state"
+    ), patch(
+        "mxops.execution.steps.setup.MyProxyNetworkProvider.generate_blocks"
+    ):
+        step.execute()
+
+    mock_state.assert_called_once_with([fake_module_state])
+    assert mock_es.call_count == 1
+    es_ids, _, _ = mock_es.call_args.args
+    assert es_ids == {USDC}
+
+
+def test_step_overwrite_existing_balance(chain_simulator_scenario):
+    """Calling the step twice for the same (receiver, token) replaces the
+    prior amount with the new one — no merge logic, no read-before-write,
+    just a fresh set_address_state call with the new encoded value."""
+    step1 = _make_step(
+        [{"receiver": MOCK_BECH32_A, "token_identifier": USDC, "amount": 100}]
+    )
+    step2 = _make_step(
+        [{"receiver": MOCK_BECH32_A, "token_identifier": USDC, "amount": 9999}]
+    )
+
+    *_, mock_addr1, _ = _patched_run(step1)
+    *_, mock_addr2, _ = _patched_run(step2)
+
+    usdc_key = _build_fungible_esdt_storage_key(USDC)
+    assert mock_addr1.call_args_list[0].args == (
+        MOCK_BECH32_A,
+        {usdc_key: _encode_fungible_esdt_value(100)},
+    )
+    assert mock_addr2.call_args_list[0].args == (
+        MOCK_BECH32_A,
+        {usdc_key: _encode_fungible_esdt_value(9999)},
+    )
+    # No accidental merging: encoded payload for 100 != encoded payload for 9999.
+    assert _encode_fungible_esdt_value(100) != _encode_fungible_esdt_value(9999)


### PR DESCRIPTION
## Summary

Add a new chain-simulator-only step `ChainSimulatorSetTokenBalanceStep` that enables creating arbitrary fungible ESDT token balances "from thin air" on accounts. This is useful for test scenarios where you want to set up specific token balances without needing to clone accounts from a source network.

## Key Features

- **Fungible tokens only (v1)**: Supports setting arbitrary amounts for standard ESDT tokens
- **Automatic token registration**: If a token doesn't exist on the chain simulator, it's automatically cloned from the source network (default: mainnet)
- **Multi-receiver support**: Set balances for multiple accounts in a single step
- **Storage preservation**: Uses `set_address_state()` to surgically update balances without affecting other account state (code, nonce, balance)
- **Idempotent behavior**: Re-running with the same or different amounts updates balances cleanly

## Changes

- `ChainSimulatorSetTokenBalanceStep` implementation with protobuf encoding for ESDT values
- Helper functions for storage key generation and value encoding
- Support for reusing existing ESDT token reconciliation logic from `AccountCloneStep`
- 28 unit tests covering encoding, validation, and execution paths
- Integration test demonstrating end-to-end balance creation and verification
- User and developer documentation

## Testing

- All 296 unit tests pass (including 28 new tests for this step)
- All code quality gates pass (bandit, flake8, ruff, pylint > 9.5)
- Integration test successfully creates balances on chain simulator and verifies via proxy queries